### PR TITLE
chore: update git2 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 # Default enable napi4 feature, see https://nodejs.org/api/n-api.html#node-api-version-matrix
 napi = { version = "2.10.0", default-features = false, features = ["napi4", "error_anyhow"] }
 napi-derive = "2.9.1"
-git2 = {version="0.15", features = ["vendored-libgit2", "vendored-openssl"]}
+git2 = {version="0.17.1", features = ["vendored-libgit2", "vendored-openssl"]}
 anyhow = "1.0.66"
 serde = "1.0.147"
 


### PR DESCRIPTION
### 왜 올렸나요?
- git2 가 0.17.1 이 나와서 업데이트합니다.
- 링크: https://docs.rs/git2/latest/git2/#