### PR TITLE
chore: es-git -> esgit@0.0.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 env:
   DEBUG: napi:*
-  APP_NAME: es-git
+  APP_NAME: esgit
   MACOSX_DEPLOYMENT_TARGET: '10.13'
 on:
   pull_request:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       - 'v*.*.*'
 env:
   DEBUG: napi:*
-  APP_NAME: es-git
+  APP_NAME: esgit
   MACOSX_DEPLOYMENT_TARGET: '10.13'
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -203,4 +203,4 @@ Cargo.lock
 npm
 
 # Generated
-es-git.d.ts
+esgit.d.ts

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 edition = "2021"
-name    = "es-git"
+name    = "esgit"
 version = "0.0.0"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# es-git
+# esgit

--- a/biome.json
+++ b/biome.json
@@ -9,7 +9,7 @@
     "useIgnoreFile": true
   },
   "files": {
-    "ignore": ["./.yarn/**", "*.json", "./index.js", "./es-git.d.ts", "./index.d.ts"]
+    "ignore": ["./.yarn/**", "*.json", "./index.js", "./esgit.d.ts", "./index.d.ts"]
   },
   "formatter": {
     "enabled": true,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { RepositoryState } from './es-git';
-
 /**
  * TODO:
  * napi does not support union types when converting rust enum types to TypeScript.

--- a/index.js
+++ b/index.js
@@ -32,24 +32,24 @@ switch (platform) {
   case 'android':
     switch (arch) {
       case 'arm64':
-        localFileExisted = existsSync(join(__dirname, 'es-git.android-arm64.node'))
+        localFileExisted = existsSync(join(__dirname, 'esgit.android-arm64.node'))
         try {
           if (localFileExisted) {
-            nativeBinding = require('./es-git.android-arm64.node')
+            nativeBinding = require('./esgit.android-arm64.node')
           } else {
-            nativeBinding = require('es-git-android-arm64')
+            nativeBinding = require('esgit-android-arm64')
           }
         } catch (e) {
           loadError = e
         }
         break
       case 'arm':
-        localFileExisted = existsSync(join(__dirname, 'es-git.android-arm-eabi.node'))
+        localFileExisted = existsSync(join(__dirname, 'esgit.android-arm-eabi.node'))
         try {
           if (localFileExisted) {
-            nativeBinding = require('./es-git.android-arm-eabi.node')
+            nativeBinding = require('./esgit.android-arm-eabi.node')
           } else {
-            nativeBinding = require('es-git-android-arm-eabi')
+            nativeBinding = require('esgit-android-arm-eabi')
           }
         } catch (e) {
           loadError = e
@@ -63,13 +63,13 @@ switch (platform) {
     switch (arch) {
       case 'x64':
         localFileExisted = existsSync(
-          join(__dirname, 'es-git.win32-x64-msvc.node')
+          join(__dirname, 'esgit.win32-x64-msvc.node')
         )
         try {
           if (localFileExisted) {
-            nativeBinding = require('./es-git.win32-x64-msvc.node')
+            nativeBinding = require('./esgit.win32-x64-msvc.node')
           } else {
-            nativeBinding = require('es-git-win32-x64-msvc')
+            nativeBinding = require('esgit-win32-x64-msvc')
           }
         } catch (e) {
           loadError = e
@@ -77,13 +77,13 @@ switch (platform) {
         break
       case 'ia32':
         localFileExisted = existsSync(
-          join(__dirname, 'es-git.win32-ia32-msvc.node')
+          join(__dirname, 'esgit.win32-ia32-msvc.node')
         )
         try {
           if (localFileExisted) {
-            nativeBinding = require('./es-git.win32-ia32-msvc.node')
+            nativeBinding = require('./esgit.win32-ia32-msvc.node')
           } else {
-            nativeBinding = require('es-git-win32-ia32-msvc')
+            nativeBinding = require('esgit-win32-ia32-msvc')
           }
         } catch (e) {
           loadError = e
@@ -91,13 +91,13 @@ switch (platform) {
         break
       case 'arm64':
         localFileExisted = existsSync(
-          join(__dirname, 'es-git.win32-arm64-msvc.node')
+          join(__dirname, 'esgit.win32-arm64-msvc.node')
         )
         try {
           if (localFileExisted) {
-            nativeBinding = require('./es-git.win32-arm64-msvc.node')
+            nativeBinding = require('./esgit.win32-arm64-msvc.node')
           } else {
-            nativeBinding = require('es-git-win32-arm64-msvc')
+            nativeBinding = require('esgit-win32-arm64-msvc')
           }
         } catch (e) {
           loadError = e
@@ -108,23 +108,23 @@ switch (platform) {
     }
     break
   case 'darwin':
-    localFileExisted = existsSync(join(__dirname, 'es-git.darwin-universal.node'))
+    localFileExisted = existsSync(join(__dirname, 'esgit.darwin-universal.node'))
     try {
       if (localFileExisted) {
-        nativeBinding = require('./es-git.darwin-universal.node')
+        nativeBinding = require('./esgit.darwin-universal.node')
       } else {
-        nativeBinding = require('es-git-darwin-universal')
+        nativeBinding = require('esgit-darwin-universal')
       }
       break
     } catch {}
     switch (arch) {
       case 'x64':
-        localFileExisted = existsSync(join(__dirname, 'es-git.darwin-x64.node'))
+        localFileExisted = existsSync(join(__dirname, 'esgit.darwin-x64.node'))
         try {
           if (localFileExisted) {
-            nativeBinding = require('./es-git.darwin-x64.node')
+            nativeBinding = require('./esgit.darwin-x64.node')
           } else {
-            nativeBinding = require('es-git-darwin-x64')
+            nativeBinding = require('esgit-darwin-x64')
           }
         } catch (e) {
           loadError = e
@@ -132,13 +132,13 @@ switch (platform) {
         break
       case 'arm64':
         localFileExisted = existsSync(
-          join(__dirname, 'es-git.darwin-arm64.node')
+          join(__dirname, 'esgit.darwin-arm64.node')
         )
         try {
           if (localFileExisted) {
-            nativeBinding = require('./es-git.darwin-arm64.node')
+            nativeBinding = require('./esgit.darwin-arm64.node')
           } else {
-            nativeBinding = require('es-git-darwin-arm64')
+            nativeBinding = require('esgit-darwin-arm64')
           }
         } catch (e) {
           loadError = e
@@ -152,12 +152,12 @@ switch (platform) {
     if (arch !== 'x64') {
       throw new Error(`Unsupported architecture on FreeBSD: ${arch}`)
     }
-    localFileExisted = existsSync(join(__dirname, 'es-git.freebsd-x64.node'))
+    localFileExisted = existsSync(join(__dirname, 'esgit.freebsd-x64.node'))
     try {
       if (localFileExisted) {
-        nativeBinding = require('./es-git.freebsd-x64.node')
+        nativeBinding = require('./esgit.freebsd-x64.node')
       } else {
-        nativeBinding = require('es-git-freebsd-x64')
+        nativeBinding = require('esgit-freebsd-x64')
       }
     } catch (e) {
       loadError = e
@@ -168,26 +168,26 @@ switch (platform) {
       case 'x64':
         if (isMusl()) {
           localFileExisted = existsSync(
-            join(__dirname, 'es-git.linux-x64-musl.node')
+            join(__dirname, 'esgit.linux-x64-musl.node')
           )
           try {
             if (localFileExisted) {
-              nativeBinding = require('./es-git.linux-x64-musl.node')
+              nativeBinding = require('./esgit.linux-x64-musl.node')
             } else {
-              nativeBinding = require('es-git-linux-x64-musl')
+              nativeBinding = require('esgit-linux-x64-musl')
             }
           } catch (e) {
             loadError = e
           }
         } else {
           localFileExisted = existsSync(
-            join(__dirname, 'es-git.linux-x64-gnu.node')
+            join(__dirname, 'esgit.linux-x64-gnu.node')
           )
           try {
             if (localFileExisted) {
-              nativeBinding = require('./es-git.linux-x64-gnu.node')
+              nativeBinding = require('./esgit.linux-x64-gnu.node')
             } else {
-              nativeBinding = require('es-git-linux-x64-gnu')
+              nativeBinding = require('esgit-linux-x64-gnu')
             }
           } catch (e) {
             loadError = e
@@ -197,26 +197,26 @@ switch (platform) {
       case 'arm64':
         if (isMusl()) {
           localFileExisted = existsSync(
-            join(__dirname, 'es-git.linux-arm64-musl.node')
+            join(__dirname, 'esgit.linux-arm64-musl.node')
           )
           try {
             if (localFileExisted) {
-              nativeBinding = require('./es-git.linux-arm64-musl.node')
+              nativeBinding = require('./esgit.linux-arm64-musl.node')
             } else {
-              nativeBinding = require('es-git-linux-arm64-musl')
+              nativeBinding = require('esgit-linux-arm64-musl')
             }
           } catch (e) {
             loadError = e
           }
         } else {
           localFileExisted = existsSync(
-            join(__dirname, 'es-git.linux-arm64-gnu.node')
+            join(__dirname, 'esgit.linux-arm64-gnu.node')
           )
           try {
             if (localFileExisted) {
-              nativeBinding = require('./es-git.linux-arm64-gnu.node')
+              nativeBinding = require('./esgit.linux-arm64-gnu.node')
             } else {
-              nativeBinding = require('es-git-linux-arm64-gnu')
+              nativeBinding = require('esgit-linux-arm64-gnu')
             }
           } catch (e) {
             loadError = e
@@ -226,26 +226,26 @@ switch (platform) {
       case 'arm':
         if (isMusl()) {
           localFileExisted = existsSync(
-            join(__dirname, 'es-git.linux-arm-musleabihf.node')
+            join(__dirname, 'esgit.linux-arm-musleabihf.node')
           )
           try {
             if (localFileExisted) {
-              nativeBinding = require('./es-git.linux-arm-musleabihf.node')
+              nativeBinding = require('./esgit.linux-arm-musleabihf.node')
             } else {
-              nativeBinding = require('es-git-linux-arm-musleabihf')
+              nativeBinding = require('esgit-linux-arm-musleabihf')
             }
           } catch (e) {
             loadError = e
           }
         } else {
           localFileExisted = existsSync(
-            join(__dirname, 'es-git.linux-arm-gnueabihf.node')
+            join(__dirname, 'esgit.linux-arm-gnueabihf.node')
           )
           try {
             if (localFileExisted) {
-              nativeBinding = require('./es-git.linux-arm-gnueabihf.node')
+              nativeBinding = require('./esgit.linux-arm-gnueabihf.node')
             } else {
-              nativeBinding = require('es-git-linux-arm-gnueabihf')
+              nativeBinding = require('esgit-linux-arm-gnueabihf')
             }
           } catch (e) {
             loadError = e
@@ -255,26 +255,26 @@ switch (platform) {
       case 'riscv64':
         if (isMusl()) {
           localFileExisted = existsSync(
-            join(__dirname, 'es-git.linux-riscv64-musl.node')
+            join(__dirname, 'esgit.linux-riscv64-musl.node')
           )
           try {
             if (localFileExisted) {
-              nativeBinding = require('./es-git.linux-riscv64-musl.node')
+              nativeBinding = require('./esgit.linux-riscv64-musl.node')
             } else {
-              nativeBinding = require('es-git-linux-riscv64-musl')
+              nativeBinding = require('esgit-linux-riscv64-musl')
             }
           } catch (e) {
             loadError = e
           }
         } else {
           localFileExisted = existsSync(
-            join(__dirname, 'es-git.linux-riscv64-gnu.node')
+            join(__dirname, 'esgit.linux-riscv64-gnu.node')
           )
           try {
             if (localFileExisted) {
-              nativeBinding = require('./es-git.linux-riscv64-gnu.node')
+              nativeBinding = require('./esgit.linux-riscv64-gnu.node')
             } else {
-              nativeBinding = require('es-git-linux-riscv64-gnu')
+              nativeBinding = require('esgit-linux-riscv64-gnu')
             }
           } catch (e) {
             loadError = e
@@ -283,13 +283,13 @@ switch (platform) {
         break
       case 's390x':
         localFileExisted = existsSync(
-          join(__dirname, 'es-git.linux-s390x-gnu.node')
+          join(__dirname, 'esgit.linux-s390x-gnu.node')
         )
         try {
           if (localFileExisted) {
-            nativeBinding = require('./es-git.linux-s390x-gnu.node')
+            nativeBinding = require('./esgit.linux-s390x-gnu.node')
           } else {
-            nativeBinding = require('es-git-linux-s390x-gnu')
+            nativeBinding = require('esgit-linux-s390x-gnu')
           }
         } catch (e) {
           loadError = e

--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
 {
-  "name": "es-git",
-  "version": "0.0.0",
+  "name": "esgit",
+  "version": "0.0.11",
   "main": "index.js",
   "types": "index.d.ts",
   "files": [
     "index.js",
     "index.d.ts"
   ],
-  "bugs": "https://github.com/toss/es-git/issues",
+  "bugs": "https://github.com/toss/esgit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/toss/es-git.git"
+    "url": "https://github.com/toss/esgit.git"
   },
   "license": "MIT",
   "packageManager": "yarn@4.5.1",
   "napi": {
-    "name": "es-git",
+    "name": "esgit",
     "triples": {
       "defaults": false,
       "additional": [
@@ -32,8 +32,8 @@
   },
   "scripts": {
     "prepublishOnly": "napi prepublish -t npm",
-    "build": "napi build --platform --release --dts=es-git.d.ts",
-    "build:debug": "napi build --platform --dts=es-git.d.ts",
+    "build": "napi build --platform --release --dts=esgit.d.ts",
+    "build:debug": "napi build --platform --dts=esgit.d.ts",
     "check": "biome check",
     "check:fix": "biome check --write --unsafe"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -789,19 +789,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-git@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "es-git@workspace:."
-  dependencies:
-    "@biomejs/biome": "npm:^1.9.4"
-    "@napi-rs/cli": "npm:^2.18.4"
-    "@types/node": "npm:^22.8.4"
-    tiny-glob: "npm:^0.2.9"
-    typescript: "npm:^5.6.3"
-    vitest: "npm:^2.1.4"
-  languageName: unknown
-  linkType: soft
-
 "esbuild@npm:^0.21.3":
   version: 0.21.5
   resolution: "esbuild@npm:0.21.5"
@@ -881,6 +868,19 @@ __metadata:
   checksum: 10c0/fa08508adf683c3f399e8a014a6382a6b65542213431e26206c0720e536b31c09b50798747c2a105a4bbba1d9767b8d3615a74c2f7bf1ddf6d836cd11eb672de
   languageName: node
   linkType: hard
+
+"esgit@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "esgit@workspace:."
+  dependencies:
+    "@biomejs/biome": "npm:^1.9.4"
+    "@napi-rs/cli": "npm:^2.18.4"
+    "@types/node": "npm:^22.8.4"
+    tiny-glob: "npm:^0.2.9"
+    typescript: "npm:^5.6.3"
+    vitest: "npm:^2.1.4"
+  languageName: unknown
+  linkType: soft
 
 "estree-walker@npm:^3.0.3":
   version: 3.0.3


### PR DESCRIPTION
Since npm detects spam when we rename package into `es-git`, so rollback #9 