### PR TITLE
docs: add bun installation instructions for es-git

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -56,6 +56,10 @@ pnpm add es-git
 yarn add es-git
 ```
 
+```sh [bun]
+bun add es-git
+```
+
 :::
 
 ## Links

--- a/docs/ko/getting-started.md
+++ b/docs/ko/getting-started.md
@@ -54,6 +54,10 @@ pnpm add es-git
 yarn add es-git
 ```
 
+```sh [bun]
+bun add es-git
+```
+
 :::
 
 ## 링크


### PR DESCRIPTION
This PR adds instructions for installing `es-git` using [Bun](https://bun.sh/), a modern JavaScript runtime.  
Since Bun supports npm packages and offers faster install times, I believe it would be helpful to include this in the Installation section for users who use Bun as their package manager.

Thank you for this great project!