### PR TITLE
chore: prepare release 0.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,15 +149,27 @@ jobs:
           ignore-case: true
           omit-heading: true
       - run: 'cat ${{ steps.extract-changelog.outputs.output-file }}'
-      - if: |
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          body_path: ${{ steps.extract-changelog.outputs.output-file }}
+          repository: toss/es-git
+          generate_release_notes: false
+          token: ${{ github.token }}
+      - name: Publish
+        if: |
           github.event_name == 'push' &&
           (github.ref_type == 'tag' || github.ref == 'refs/heads/main')
         run: |
           set -ex
+          npm config set provenance true
           npm config set //registry.npmjs.org/:_authToken "$NPM_AUTH_TOKEN"
           npm whoami
           if [[ "$GITHUB_REF_TYPE" = "tag" ]]; then
-            npm publish
+            npm publish --access public
+          else
+            npm publish --access public --tag next
           fi
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,5 @@
 # Changelog
+
+## Version v0.1.0
+
+Initial release. Released on March 25th, 2024.


### PR DESCRIPTION
- Update changelog for v0.1.0
- Publish `@next` version when main branch updated
- Update release notes