### PR TITLE
test: use `ubuntu-24.04-arm` for testing linux aarch64 gnu binding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,7 +315,7 @@ jobs:
         node:
           - '18'
           - '20'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       - name: Download artifacts
@@ -331,16 +331,5 @@ jobs:
           yarn config set supportedArchitectures.cpu "arm64"
           yarn config set supportedArchitectures.libc "glibc"
           yarn install
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
-      - run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-      - name: Setup and run tests
-        uses: addnab/docker-run-action@v3
-        with:
-          image: node:${{ matrix.node }}-slim
-          options: '--user 0:0 --platform linux/arm64 -v ${{ github.workspace }}:/build -w /build'
-          run: |
-            set -e
-            yarn vitest run
+      - name: Test bindings
+        run: yarn vitest run

--- a/tests/repository.spec.ts
+++ b/tests/repository.spec.ts
@@ -41,7 +41,7 @@ describe('Repository', () => {
 
   it('error if given path is not git repository', async () => {
     const p = await useFixture('notgit');
-    await expect(openRepository(p)).rejects.toThrowError();
+    await expect(openRepository(p, { noSearch: true })).rejects.toThrowError();
   });
 
   it('clone from local', async () => {


### PR DESCRIPTION
https://github.com/actions/partner-runner-images/blob/main/images/arm-ubuntu-24-image.md

GitHub supports Ubuntu 24.04 LTS Arm image as [public preview](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) since Jan 16, 2025.
