### PR TITLE
feat(bench): pre-initialize repositories for accurate benchmarks

### DIFF
--- a/benchmarks/util.ts
+++ b/benchmarks/util.ts
@@ -25,11 +25,13 @@ export function exec(command: string, cwd: string): Promise<string> {
   });
 }
 
+type BenchmarkOptions = Omit<BenchOptions, "setup">;
+
 export function createBenchmark(gitDir: string) {
   const benchESGit = (
     name: string,
     operation: (repo: Repository) => unknown | Promise<unknown>,
-    options?: BenchOptions
+    options?: BenchmarkOptions
   ) => {
     let esGitRepo: Repository;
     bench(
@@ -50,7 +52,7 @@ export function createBenchmark(gitDir: string) {
   const benchNodeGit = (
     name: string,
     operation: (repo: NodeGitRepository) => unknown | Promise<unknown>,
-    options?: BenchOptions
+    options?: BenchmarkOptions
   ) => {
     let nodeGitRepo: NodeGitRepository;
     bench(
@@ -71,7 +73,7 @@ export function createBenchmark(gitDir: string) {
   const benchSimpleGit = (
     name: string,
     operation: (repo: SimpleGitRepository) => unknown | Promise<unknown>,
-    options?: BenchOptions
+    options?: BenchmarkOptions
   ) => {
     let simpleGitRepo: SimpleGitRepository;
     bench(

--- a/benchmarks/util.ts
+++ b/benchmarks/util.ts
@@ -1,6 +1,10 @@
 import { exec as execChildProcess } from 'node:child_process';
+import { Repository as SimpleGitRepository } from '@napi-rs/simple-git';
+import { Repository as NodeGitRepository } from 'nodegit';
+import { type BenchOptions, bench } from 'vitest';
+import { type Repository, openRepository } from '../index';
 
-export function exec(command: string, cwd: string) {
+export function exec(command: string, cwd: string): Promise<string> {
   return new Promise<string>((resolve, reject) => {
     let output = '';
     const cp = execChildProcess(
@@ -19,4 +23,86 @@ export function exec(command: string, cwd: string) {
     );
     cp.on('close', () => resolve(output));
   });
+}
+
+export function createBenchmark(gitDir: string) {
+  const benchESGit = (
+    name: string,
+    operation: (repo: Repository) => unknown | Promise<unknown>,
+    options?: BenchOptions
+  ) => {
+    let esGitRepo: Repository;
+    bench(
+      name,
+      async () => {
+        if (!esGitRepo) throw new Error('Setup failed for es-git benchmark');
+        await operation(esGitRepo);
+      },
+      {
+        setup: async () => {
+          esGitRepo = await openRepository(gitDir);
+        },
+        ...options,
+      }
+    );
+  };
+
+  const benchNodeGit = (
+    name: string,
+    operation: (repo: NodeGitRepository) => unknown | Promise<unknown>,
+    options?: BenchOptions
+  ) => {
+    let nodeGitRepo: NodeGitRepository;
+    bench(
+      name,
+      async () => {
+        if (!nodeGitRepo) throw new Error('Setup failed for nodegit benchmark');
+        await operation(nodeGitRepo);
+      },
+      {
+        setup: async () => {
+          nodeGitRepo = await NodeGitRepository.open(gitDir);
+        },
+        ...options,
+      }
+    );
+  };
+
+  const benchSimpleGit = (
+    name: string,
+    operation: (repo: SimpleGitRepository) => unknown | Promise<unknown>,
+    options?: BenchOptions
+  ) => {
+    let simpleGitRepo: SimpleGitRepository;
+    bench(
+      name,
+      () => {
+        if (!simpleGitRepo) throw new Error('Setup failed for simple-git benchmark');
+        operation(simpleGitRepo);
+      },
+      {
+        setup: () => {
+          simpleGitRepo = new SimpleGitRepository(gitDir);
+        },
+        ...options,
+      }
+    );
+  };
+
+  const benchChildProcess = (name: string, operation: () => unknown | Promise<unknown>, options?: BenchOptions) => {
+    bench(
+      name,
+      async () => {
+        await operation();
+      },
+      options
+    );
+  };
+
+  return {
+    esGit: benchESGit,
+    nodegit: benchNodeGit,
+    simpleGit: benchSimpleGit,
+    childProcess: benchChildProcess,
+  };
 }


### PR DESCRIPTION
## Problem
The previous benchmark setup initialized repositories within each test function. This caused the repository opening time to be included in the measurements for all tests (`rev-parse`, `revwalk`, `get commit`, etc.), not just the `open` test, leading to inaccurate results.

## Solution
Refactored the benchmark setup to use tinybench's `setup` task. This initializes the repositories for `es-git`, `nodegit`, and `@napi-rs/simple-git` once before all tests run. Subsequent benchmark tests then reuse these pre-initialized repository instances.

## Expected Outcome
This change ensures that benchmarks for specific Git operations measure only the performance of those operations, providing a more accurate and reliable comparison between the libraries. The `open` benchmark remains dedicated to measuring repository opening performance.