### PR TITLE
fix(bench): incorrect opening method in @napi-rs/simple-git repository

### DIFF
--- a/benchmarks/index.bench.ts
+++ b/benchmarks/index.bench.ts
@@ -21,7 +21,7 @@ describe('open', () => {
   });
 
   bench('@napi-rs/simple-git', () => {
-    SimpleGitRepository.init(gitDir);
+    new SimpleGitRepository(gitDir);
   });
 });
 


### PR DESCRIPTION
## Description
This PR corrects the method used to open an existing repository in the benchmark code (`benchmarks/index.bench.ts`) for `@napi-rs/simple-git`.

## Problem
The benchmark test for opening a repository in `@napi-rs/simple-git` was incorrectly using the `SimpleGitRepository.init(gitDir)` method. This method initializes a **new** repository, whereas the benchmark should be testing the opening of an **existing** repository. This usage contradicts the intended functionality documented in the library.

According to the library documentation:
*   `Repository.init('/path/to/repo')`: Initializes a **new** Git repository at the specified path.
*   `new Repository('/path/to/repo')`: Opens an **existing** repository.

In the context of this benchmark, the goal is to measure the performance of opening a pre-existing repository. Therefore, the use of `init` was incorrect.

## Solution
The benchmark code has been updated to use the correct method for opening an existing repository, which is the constructor call: `new SimpleGitRepository(gitDir)`.

## Expected Outcome
This correction ensures that the benchmark for the repository opening feature of `@napi-rs/simple-git` accurately reflects the correct usage pattern of the library.