### PR TITLE
fix(docs): use yarn dlx for Vercel CLI

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,11 +17,9 @@ jobs:
           cache: yarn
       - name: Install dependencies
         run: yarn install
-      - name: Install Vercel CLI
-        run: yarn global add vercel
       - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        run: yarn dlx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
       - name: Build Project Artifacts
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: yarn dlx vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: yarn dlx vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,11 +199,9 @@ jobs:
           cache: yarn
       - name: Install dependencies
         run: yarn install
-      - name: Install Vercel CLI
-        run: yarn global add vercel
       - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        run: yarn dlx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
       - name: Build Project Artifacts
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: yarn dlx vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: yarn dlx vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Description
This PR fixes a mistake I made in the previous implementation, Vercel CLI is executed in the documentation deployment
## Testing
This change has been successfully tested in a GitHub Actions workflow within my personal fork of the `es-git` repository. The results of the successful run can be viewed here:
https://github.com/other-yuka/es-git/actions/runs/14683403302/job/41208918764
