### PR TITLE
fix: resolve clippy lint errors with inline format arguments

### DIFF
--- a/src/blame.rs
+++ b/src/blame.rs
@@ -308,7 +308,7 @@ impl Blame {
     let hunk = self
       .inner
       .get_index(index as usize)
-      .ok_or_else(|| Error::new(Status::InvalidArg, format!("No blame hunk found at index {}", index)))?;
+      .ok_or_else(|| Error::new(Status::InvalidArg, format!("No blame hunk found at index {index}")))?;
 
     Ok(BlameHunk::from(&hunk))
   }
@@ -331,7 +331,7 @@ impl Blame {
     let hunk = self
       .inner
       .get_line(line as usize)
-      .ok_or_else(|| Error::new(Status::InvalidArg, format!("No blame hunk found for line {}", line)))?;
+      .ok_or_else(|| Error::new(Status::InvalidArg, format!("No blame hunk found for line {line}")))?;
 
     Ok(BlameHunk::from(&hunk))
   }

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -451,7 +451,7 @@ impl Reference {
         .rename(
           &new_name,
           force.unwrap_or_default(),
-          &msg.unwrap_or(format!("Renaming reference into {}", new_name)),
+          &msg.unwrap_or(format!("Renaming reference into {new_name}")),
         )
         .map_err(crate::Error::from)
         .map_err(|e| e.into())


### PR DESCRIPTION
This PR fixes clippy lint errors that were causing the `just lint` command to fail. The errors were related to `clippy::uninlined_format_args` which requires using inline format arguments in
  `format!` macros.

> This fix was separated from #132 to address lint errors independently.