### PR TITLE
feat: add missing `wt_unreaddable` field in status by upgrading git2-rs v0.20.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5220b8ba44c68a9a7f7a7659e864dd73692e417ef0211bea133c7b74e031eeb9"
+checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
 dependencies = [
  "bitflags",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 [dependencies]
 bitflags    = "2.1.0"
 chrono      = "0.4"
-git2        = { version = "0.20.1", features = ["vendored-libgit2", "vendored-openssl"] }
+git2        = { version = "0.20.2", features = ["vendored-libgit2", "vendored-openssl"] }
 napi        = { version = "2.16.17", default-features = false, features = ["napi6", "chrono_date"] }
 napi-derive = "2.16.13"
 thiserror   = "2.0.3"

--- a/index.d.ts
+++ b/index.d.ts
@@ -1820,6 +1820,7 @@ export interface Status {
   wtDeleted: boolean
   wtTypechange: boolean
   wtRenamed: boolean
+  wtUnreadable: boolean
   ignored: boolean
   conflicted: boolean
 }

--- a/src/status.rs
+++ b/src/status.rs
@@ -18,9 +18,7 @@ pub struct Status {
   pub wt_deleted: bool,
   pub wt_typechange: bool,
   pub wt_renamed: bool,
-  // TODO: Field does not exist on current `git2-rs` version.
-  // Wait for updates (https://github.com/rust-lang/git2-rs/pull/1151)
-  // pub wt_unreadable: bool,
+  pub wt_unreadable: bool,
   pub ignored: bool,
   pub conflicted: bool,
 }
@@ -38,6 +36,7 @@ impl From<git2::Status> for Status {
     let wt_deleted = value.contains(git2::Status::WT_DELETED);
     let wt_typechange = value.contains(git2::Status::WT_TYPECHANGE);
     let wt_renamed = value.contains(git2::Status::WT_RENAMED);
+    let wt_unreadable = value.contains(git2::Status::WT_UNREADABLE);
     let ignored = value.contains(git2::Status::IGNORED);
     let conflicted = value.contains(git2::Status::CONFLICTED);
     Self {
@@ -52,6 +51,7 @@ impl From<git2::Status> for Status {
       wt_deleted,
       wt_typechange,
       wt_renamed,
+      wt_unreadable,
       ignored,
       conflicted,
     }


### PR DESCRIPTION
https://github.com/rust-lang/git2-rs/blob/master/CHANGELOG.md#0202---2025-05-05

In the above git2-rs 0.20.2 changelog, we can see that the `Status::WT UNREADABLE` field was added, and the `wt_unreadable` field is added via the updating dependency.