### PR TITLE
feat: implements revert feature

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1624,6 +1624,32 @@ export declare function discoverRepository(path: string, signal?: AbortSignal | 
  * ```
  */
 export declare function cloneRepository(url: string, path: string, options?: RepositoryCloneOptions | undefined | null, signal?: AbortSignal | undefined | null): Promise<Repository>
+/**
+ * Options for revert behavior.
+ *
+ * Controls how a revert is performed when applying the inverse of a commit.
+ *
+ * @example
+ * ```ts
+ * import { openRepository } from 'es-git';
+ *
+ * const repo = await openRepository('./path/to/repo');
+ * const head = repo.head().target()!;
+ * const commit = repo.getCommit(head);
+ *
+ * // Simple revert
+ * repo.revert(commit);
+ * repo.cleanupState();
+ *
+ * // Revert a merge commit selecting the first parent as mainline
+ * repo.revert(commit, { mainline: 1 });
+ * repo.cleanupState();
+ *
+ * // Prevent working tree changes (dry run) but compute conflicts
+ * repo.revert(commit, { checkoutOptions: { dryRun: true } });
+ * repo.cleanupState();
+ * ```
+ */
 export interface RevertOptions {
   /**
    * Parent number for merge commits (1-based).
@@ -5164,6 +5190,16 @@ export declare class Repository {
    * ```
    *
    * @returns The current state of this repository.
+   *
+   * @example
+   * ```ts
+   * import { openRepository } from 'es-git';
+   *
+   * const repo = await openRepository('./repo');
+   * console.log(repo.state()); // e.g., 'Clean'
+   * // After a revert/merge/cherry-pick, state can be 'Revert'/'Merge' etc.
+   * // Use repo.cleanupState() to return to 'Clean' when done handling.
+   * ```
    */
   state(): RepositoryState
   /**
@@ -5328,6 +5364,17 @@ export declare class Repository {
    *   cleanupState(): void;
    * }
    * ```
+   *
+   * @example
+   * ```ts
+   * import { openRepository } from 'es-git';
+   *
+   * const repo = await openRepository('./repo');
+   * // After revert or merge operations:
+   * if (repo.state() !== 'Clean') {
+   *   repo.cleanupState();
+   * }
+   * ```
    */
   cleanupState(): void
   /**
@@ -5349,6 +5396,23 @@ export declare class Repository {
    * @param {RevertOptions} [options] - Options for the revert operation.
    * @throws {Error} If the commit is a merge commit and no mainline is specified.
    * @throws {Error} If there are conflicts during the revert operation.
+   *
+   * @example
+   * ```ts
+   * import { openRepository } from 'es-git';
+   *
+   * const repo = await openRepository('./path/to/repo');
+   * const last = repo.head().target()!;
+   * const commit = repo.getCommit(last);
+   *
+   * // Revert and update working tree
+   * repo.revert(commit);
+   * repo.cleanupState();
+   *
+   * // Revert a merge commit: specify the mainline parent
+   * // repo.revert(mergeCommit, { mainline: 1 });
+   * // repo.cleanupState();
+   * ```
    */
   revert(commit: Commit, options?: RevertOptions | undefined | null): void
   /**
@@ -5375,6 +5439,20 @@ export declare class Repository {
    * @param {number} mainline - The parent of the revert commit, if it is a merge (1-based).
    * @param {MergeOptions} [mergeOptions] - Options for merge conflict resolution.
    * @returns The index result.
+   *
+   * @example
+   * ```ts
+   * import { openRepository } from 'es-git';
+   *
+   * const repo = await openRepository('./path/to/repo');
+   * const head = repo.head().target()!;
+   * const ours = repo.getCommit(head);
+   * const target = repo.getCommit(head);
+   *
+   * // Compute a revert index and apply to working tree
+   * const idx = repo.revertCommit(target, ours, 0);
+   * repo.checkoutIndex(idx);
+   * ```
    */
   revertCommit(revertCommit: Commit, ourCommit: Commit, mainline: number, mergeOptions?: MergeOptions | undefined | null): Index
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1624,6 +1624,19 @@ export declare function discoverRepository(path: string, signal?: AbortSignal | 
  * ```
  */
 export declare function cloneRepository(url: string, path: string, options?: RepositoryCloneOptions | undefined | null, signal?: AbortSignal | undefined | null): Promise<Repository>
+export interface RevertOptions {
+  /**
+   * Parent number for merge commits (1-based).
+   *
+   * When reverting a merge commit, the mainline parent is the one you want to
+   * revert to. The mainline is the branch into which the merge was made.
+   */
+  mainline?: number
+  /** Options for merge conflict resolution. */
+  mergeOptions?: MergeOptions
+  /** Options for checkout behavior when updating working directory. */
+  checkoutOptions?: CheckoutOptions
+}
 /**
  * Flags for the revparse.
  * - `Single` : The spec targeted a single object.
@@ -5317,6 +5330,53 @@ export declare class Repository {
    * ```
    */
   cleanupState(): void
+  /**
+   * Reverts the given commit, applying the inverse of its changes to the
+   * HEAD commit and the working directory.
+   *
+   * @category Repository/Methods
+   * @signature
+   * ```ts
+   * class Repository {
+   *   revert(
+   *     commit: Commit,
+   *     options?: RevertOptions | undefined | null,
+   *   ): void;
+   * }
+   * ```
+   *
+   * @param {Commit} commit - The commit to revert.
+   * @param {RevertOptions} [options] - Options for the revert operation.
+   * @throws {Error} If the commit is a merge commit and no mainline is specified.
+   * @throws {Error} If there are conflicts during the revert operation.
+   */
+  revert(commit: Commit, options?: RevertOptions | undefined | null): void
+  /**
+   * Reverts the given commit against the given "our" commit, producing an
+   * index that reflects the result of the revert.
+   *
+   * The returned index must be written to disk for the changes to take effect.
+   *
+   * @category Repository/Methods
+   * @signature
+   * ```ts
+   * class Repository {
+   *   revertCommit(
+   *     revertCommit: Commit,
+   *     ourCommit: Commit,
+   *     mainline: number,
+   *     mergeOptions?: MergeOptions | undefined | null,
+   *   ): Index;
+   * }
+   * ```
+   *
+   * @param {Commit} revertCommit - The commit to revert.
+   * @param {Commit} ourCommit - The commit to revert against (usually HEAD).
+   * @param {number} mainline - The parent of the revert commit, if it is a merge (1-based).
+   * @param {MergeOptions} [mergeOptions] - Options for merge conflict resolution.
+   * @returns The index result.
+   */
+  revertCommit(revertCommit: Commit, ourCommit: Commit, mainline: number, mergeOptions?: MergeOptions | undefined | null): Index
   /**
    * Execute a rev-parse operation against the `spec` listed.
    *

--- a/index.d.ts
+++ b/index.d.ts
@@ -5446,11 +5446,11 @@ export declare class Repository {
    *
    * const repo = await openRepository('./path/to/repo');
    * const head = repo.head().target()!;
-   * const ours = repo.getCommit(head);
+   * const our = repo.getCommit(head);
    * const target = repo.getCommit(head);
    *
    * // Compute a revert index and apply to working tree
-   * const idx = repo.revertCommit(target, ours, 0);
+   * const idx = repo.revertCommit(target, our, 0);
    * repo.checkoutIndex(idx);
    * ```
    */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod oid;
 pub mod reference;
 pub mod remote;
 pub mod repository;
+pub mod revert;
 pub mod revparse;
 pub mod revwalk;
 pub mod signature;

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -341,6 +341,16 @@ impl Repository {
   /// ```
   ///
   /// @returns The current state of this repository.
+  ///
+  /// @example
+  /// ```ts
+  /// import { openRepository } from 'es-git';
+  ///
+  /// const repo = await openRepository('./repo');
+  /// console.log(repo.state()); // e.g., 'Clean'
+  /// // After a revert/merge/cherry-pick, state can be 'Revert'/'Merge' etc.
+  /// // Use repo.cleanupState() to return to 'Clean' when done handling.
+  /// ```
   pub fn state(&self) -> RepositoryState {
     self.inner.state().into()
   }
@@ -541,6 +551,17 @@ impl Repository {
   /// ```ts
   /// class Repository {
   ///   cleanupState(): void;
+  /// }
+  /// ```
+  ///
+  /// @example
+  /// ```ts
+  /// import { openRepository } from 'es-git';
+  ///
+  /// const repo = await openRepository('./repo');
+  /// // After revert or merge operations:
+  /// if (repo.state() !== 'Clean') {
+  ///   repo.cleanupState();
   /// }
   /// ```
   pub fn cleanup_state(&self) -> crate::Result<()> {

--- a/src/revert.rs
+++ b/src/revert.rs
@@ -142,11 +142,11 @@ impl Repository {
   ///
   /// const repo = await openRepository('./path/to/repo');
   /// const head = repo.head().target()!;
-  /// const ours = repo.getCommit(head);
+  /// const our = repo.getCommit(head);
   /// const target = repo.getCommit(head);
   ///
   /// // Compute a revert index and apply to working tree
-  /// const idx = repo.revertCommit(target, ours, 0);
+  /// const idx = repo.revertCommit(target, our, 0);
   /// repo.checkoutIndex(idx);
   /// ```
   pub fn revert_commit(

--- a/src/revert.rs
+++ b/src/revert.rs
@@ -1,0 +1,110 @@
+use crate::checkout::CheckoutOptions;
+use crate::commit::Commit;
+use crate::index::Index;
+use crate::merge::MergeOptions;
+use crate::repository::Repository;
+use napi_derive::napi;
+
+#[napi(object)]
+pub struct RevertOptions {
+  /// Parent number for merge commits (1-based).
+  ///
+  /// When reverting a merge commit, the mainline parent is the one you want to
+  /// revert to. The mainline is the branch into which the merge was made.
+  pub mainline: Option<u32>,
+  /// Options for merge conflict resolution.
+  pub merge_options: Option<MergeOptions>,
+  /// Options for checkout behavior when updating working directory.
+  pub checkout_options: Option<CheckoutOptions>,
+}
+
+impl From<RevertOptions> for git2::RevertOptions<'static> {
+  fn from(value: RevertOptions) -> Self {
+    let mut opts = git2::RevertOptions::new();
+
+    if let Some(mainline) = value.mainline {
+      opts.mainline(mainline);
+    }
+
+    if let Some(merge_opts) = value.merge_options {
+      opts.merge_opts(merge_opts.into());
+    }
+
+    if let Some(checkout_opts) = value.checkout_options {
+      opts.checkout_builder(checkout_opts.into());
+    }
+
+    opts
+  }
+}
+
+#[napi]
+impl Repository {
+  #[napi]
+  /// Reverts the given commit, applying the inverse of its changes to the
+  /// HEAD commit and the working directory.
+  ///
+  /// @category Repository/Methods
+  /// @signature
+  /// ```ts
+  /// class Repository {
+  ///   revert(
+  ///     commit: Commit,
+  ///     options?: RevertOptions | undefined | null,
+  ///   ): void;
+  /// }
+  /// ```
+  ///
+  /// @param {Commit} commit - The commit to revert.
+  /// @param {RevertOptions} [options] - Options for the revert operation.
+  /// @throws {Error} If the commit is a merge commit and no mainline is specified.
+  /// @throws {Error} If there are conflicts during the revert operation.
+  pub fn revert(&self, commit: &Commit, options: Option<RevertOptions>) -> crate::Result<()> {
+    let mut git_options = options.map(Into::into);
+
+    self
+      .inner
+      .revert(&commit.inner, git_options.as_mut())
+      .map_err(crate::Error::from)?;
+
+    Ok(())
+  }
+
+  #[napi]
+  /// Reverts the given commit against the given "our" commit, producing an
+  /// index that reflects the result of the revert.
+  ///
+  /// The returned index must be written to disk for the changes to take effect.
+  ///
+  /// @category Repository/Methods
+  /// @signature
+  /// ```ts
+  /// class Repository {
+  ///   revertCommit(
+  ///     revertCommit: Commit,
+  ///     ourCommit: Commit,
+  ///     mainline: number,
+  ///     mergeOptions?: MergeOptions | undefined | null,
+  ///   ): Index;
+  /// }
+  /// ```
+  ///
+  /// @param {Commit} revertCommit - The commit to revert.
+  /// @param {Commit} ourCommit - The commit to revert against (usually HEAD).
+  /// @param {number} mainline - The parent of the revert commit, if it is a merge (1-based).
+  /// @param {MergeOptions} [mergeOptions] - Options for merge conflict resolution.
+  /// @returns The index result.
+  pub fn revert_commit(
+    &self,
+    revert_commit: &Commit,
+    our_commit: &Commit,
+    mainline: u32,
+    merge_options: Option<MergeOptions>,
+  ) -> crate::Result<Index> {
+    let opts = merge_options.map(git2::MergeOptions::from);
+    let inner = self
+      .inner
+      .revert_commit(&revert_commit.inner, &our_commit.inner, mainline, opts.as_ref())?;
+    Ok(Index { inner })
+  }
+}

--- a/tests/revert.spec.ts
+++ b/tests/revert.spec.ts
@@ -1,0 +1,407 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { openRepository } from '../index';
+import { useFixture } from './fixtures';
+
+describe('revert', () => {
+  const signature = { name: 'Seokju Na', email: 'seokju.me@toss.im' };
+
+  it('should revert a simple commit', async () => {
+    const p = await useFixture('empty');
+    const repo = await openRepository(p);
+
+    await fs.writeFile(path.join(p, 'file.txt'), 'initial content');
+    let index = repo.index();
+    index.addPath('file.txt');
+    const firstTreeId = index.writeTree();
+    const firstTree = repo.getTree(firstTreeId);
+    const firstOid = repo.commit(firstTree, 'first commit', {
+      updateRef: 'HEAD',
+      author: signature,
+      committer: signature,
+      parents: [repo.head().target()!],
+    });
+
+    await fs.writeFile(path.join(p, 'file.txt'), 'modified content');
+    index = repo.index();
+    index.addPath('file.txt');
+    const secondTreeId = index.writeTree();
+    const secondTree = repo.getTree(secondTreeId);
+    const secondOid = repo.commit(secondTree, 'second commit', {
+      updateRef: 'HEAD',
+      author: signature,
+      committer: signature,
+      parents: [firstOid],
+    });
+
+    const commitToRevert = repo.getCommit(secondOid);
+    repo.revert(commitToRevert);
+
+    const content = await fs.readFile(path.join(p, 'file.txt'), 'utf-8');
+    expect(content).toBe('initial content');
+
+    repo.cleanupState();
+    expect(repo.state()).toBe('Clean');
+  });
+
+  it('should revert with options', async () => {
+    const p = await useFixture('empty');
+    const repo = await openRepository(p);
+
+    await fs.writeFile(path.join(p, 'test.txt'), 'version 1');
+    let index = repo.index();
+    index.addPath('test.txt');
+    const firstTreeId = index.writeTree();
+    const firstTree = repo.getTree(firstTreeId);
+    const firstOid = repo.commit(firstTree, 'initial', {
+      updateRef: 'HEAD',
+      author: signature,
+      committer: signature,
+      parents: [repo.head().target()!],
+    });
+
+    await fs.writeFile(path.join(p, 'test.txt'), 'version 2');
+    index = repo.index();
+    index.addPath('test.txt');
+    const secondTreeId = index.writeTree();
+    const secondTree = repo.getTree(secondTreeId);
+    const secondOid = repo.commit(secondTree, 'update', {
+      updateRef: 'HEAD',
+      author: signature,
+      committer: signature,
+      parents: [firstOid],
+    });
+
+    const commitToRevert = repo.getCommit(secondOid);
+    repo.revert(commitToRevert, {
+      mergeOptions: {
+        findRenames: true,
+        failOnConflict: false,
+      },
+    });
+
+    const content = await fs.readFile(path.join(p, 'test.txt'), 'utf-8');
+    expect(content).toBe('version 1');
+
+    repo.cleanupState();
+  });
+
+  it('should use revertCommit for manual index control', async () => {
+    const p = await useFixture('empty');
+    const repo = await openRepository(p);
+
+    await fs.writeFile(path.join(p, 'manual.txt'), 'original');
+    let index = repo.index();
+    index.addPath('manual.txt');
+    const firstTreeId = index.writeTree();
+    const firstTree = repo.getTree(firstTreeId);
+    const firstOid = repo.commit(firstTree, 'first', {
+      updateRef: 'HEAD',
+      author: signature,
+      committer: signature,
+      parents: [repo.head().target()!],
+    });
+    const firstCommit = repo.getCommit(firstOid);
+
+    await fs.writeFile(path.join(p, 'manual.txt'), 'changed');
+    index = repo.index();
+    index.addPath('manual.txt');
+    const secondTreeId = index.writeTree();
+    const secondTree = repo.getTree(secondTreeId);
+    const secondOid = repo.commit(secondTree, 'second', {
+      updateRef: 'HEAD',
+      author: signature,
+      committer: signature,
+      parents: [firstOid],
+    });
+    const secondCommit = repo.getCommit(secondOid);
+
+    await fs.writeFile(path.join(p, 'manual.txt'), 'changed more');
+    index = repo.index();
+    index.addPath('manual.txt');
+    const thirdTreeId = index.writeTree();
+    const thirdTree = repo.getTree(thirdTreeId);
+    const thirdOid = repo.commit(thirdTree, 'third', {
+      updateRef: 'HEAD',
+      author: signature,
+      committer: signature,
+      parents: [secondOid],
+    });
+    const thirdCommit = repo.getCommit(thirdOid);
+
+    const revertIndex = repo.revertCommit(secondCommit, thirdCommit, 0);
+
+    expect(revertIndex).toBeDefined();
+
+    expect(revertIndex.constructor.name).toBe('Index');
+  });
+
+  it('should revert merge commit with mainline', async () => {
+    const p = await useFixture('empty');
+    const repo = await openRepository(p);
+
+    await fs.writeFile(path.join(p, 'base.txt'), 'base content');
+    let index = repo.index();
+    index.addPath('base.txt');
+    const baseTreeId = index.writeTree();
+    const baseTree = repo.getTree(baseTreeId);
+    const baseOid = repo.commit(baseTree, 'base commit', {
+      updateRef: 'HEAD',
+      author: signature,
+      committer: signature,
+      parents: [repo.head().target()!],
+    });
+    const baseCommit = repo.getCommit(baseOid);
+
+    repo.createBranch('branch-a', baseCommit);
+    repo.setHead('refs/heads/branch-a');
+    await fs.writeFile(path.join(p, 'file-a.txt'), 'content A');
+    index = repo.index();
+    index.addPath('file-a.txt');
+    const aTreeId = index.writeTree();
+    const aTree = repo.getTree(aTreeId);
+    const aOid = repo.commit(aTree, 'commit A', {
+      updateRef: 'HEAD',
+      author: signature,
+      committer: signature,
+      parents: [baseOid],
+    });
+    const aCommit = repo.getCommit(aOid);
+
+    repo.createBranch('branch-b', baseCommit);
+    repo.setHead('refs/heads/branch-b');
+    repo.checkoutHead({ force: true });
+    await fs.writeFile(path.join(p, 'file-b.txt'), 'content B');
+    index = repo.index();
+    index.addPath('file-b.txt');
+    const bTreeId = index.writeTree();
+    const bTree = repo.getTree(bTreeId);
+    const bOid = repo.commit(bTree, 'commit B', {
+      updateRef: 'HEAD',
+      author: signature,
+      committer: signature,
+      parents: [baseOid],
+    });
+    const bCommit = repo.getCommit(bOid);
+
+    repo.setHead('refs/heads/branch-a');
+    repo.checkoutHead({ force: true });
+
+    await fs.writeFile(path.join(p, 'file-b.txt'), 'content B');
+    index = repo.index();
+    index.addPath('file-a.txt');
+    index.addPath('file-b.txt');
+    const mergeTreeId = index.writeTree();
+    const mergeTree = repo.getTree(mergeTreeId);
+    const mergeOid = repo.commit(mergeTree, 'merge A and B', {
+      updateRef: 'HEAD',
+      author: signature,
+      committer: signature,
+      parents: [aOid, bOid],
+    });
+    const mergeCommit = repo.getCommit(mergeOid);
+
+    repo.revert(mergeCommit, {
+      mainline: 1,
+    });
+
+    repo.cleanupState();
+
+    const fileBExists = await fs
+      .access(path.join(p, 'file-b.txt'))
+      .then(() => true)
+      .catch(() => false);
+    expect(fileBExists).toBe(false);
+
+    const fileAExists = await fs
+      .access(path.join(p, 'file-a.txt'))
+      .then(() => true)
+      .catch(() => false);
+    expect(fileAExists).toBe(true);
+  });
+
+  it('should handle revert state', async () => {
+    const p = await useFixture('empty');
+    const repo = await openRepository(p);
+
+    await fs.writeFile(path.join(p, 'state-test.txt'), 'initial');
+    let index = repo.index();
+    index.addPath('state-test.txt');
+    const firstTreeId = index.writeTree();
+    const firstTree = repo.getTree(firstTreeId);
+    const firstOid = repo.commit(firstTree, 'first', {
+      updateRef: 'HEAD',
+      author: signature,
+      committer: signature,
+      parents: [repo.head().target()!],
+    });
+
+    await fs.writeFile(path.join(p, 'state-test.txt'), 'modified');
+    index = repo.index();
+    index.addPath('state-test.txt');
+    const secondTreeId = index.writeTree();
+    const secondTree = repo.getTree(secondTreeId);
+    const secondOid = repo.commit(secondTree, 'second', {
+      updateRef: 'HEAD',
+      author: signature,
+      committer: signature,
+      parents: [firstOid],
+    });
+
+    expect(repo.state()).toBe('Clean');
+
+    const commitToRevert = repo.getCommit(secondOid);
+    repo.revert(commitToRevert);
+
+    repo.cleanupState();
+    expect(repo.state()).toBe('Clean');
+
+    repo.cleanupState();
+    expect(repo.state()).toBe('Clean');
+  });
+
+  it('should fail when reverting merge commit without mainline', async () => {
+    const p = await useFixture('empty');
+    const repo = await openRepository(p);
+
+    await fs.writeFile(path.join(p, 'base.txt'), 'base');
+    let index = repo.index();
+    index.addPath('base.txt');
+    const baseTreeId = index.writeTree();
+    const baseTree = repo.getTree(baseTreeId);
+    const baseOid = repo.commit(baseTree, 'base', {
+      updateRef: 'HEAD',
+      author: signature,
+      committer: signature,
+      parents: [repo.head().target()!],
+    });
+
+    const baseCommit = repo.getCommit(baseOid);
+    repo.createBranch('feature', baseCommit);
+
+    await fs.writeFile(path.join(p, 'main.txt'), 'main');
+    index = repo.index();
+    index.addPath('main.txt');
+    const mainTreeId = index.writeTree();
+    const mainTree = repo.getTree(mainTreeId);
+    const mainOid = repo.commit(mainTree, 'main commit', {
+      updateRef: 'HEAD',
+      author: signature,
+      committer: signature,
+      parents: [baseOid],
+    });
+
+    await fs.writeFile(path.join(p, 'feature.txt'), 'feature');
+    index = repo.index();
+    index.addPath('feature.txt');
+    const featureTreeId = index.writeTree();
+    const featureTree = repo.getTree(featureTreeId);
+    const featureOid = repo.commit(featureTree, 'feature commit', {
+      updateRef: 'refs/heads/feature',
+      author: signature,
+      committer: signature,
+      parents: [baseOid],
+    });
+
+    index = repo.index();
+    await fs.writeFile(path.join(p, 'main.txt'), 'main');
+    await fs.writeFile(path.join(p, 'feature.txt'), 'feature');
+    index.addPath('main.txt');
+    index.addPath('feature.txt');
+    const mergeTreeId = index.writeTree();
+    const mergeTree = repo.getTree(mergeTreeId);
+    const mergeOid = repo.commit(mergeTree, 'merge', {
+      updateRef: 'HEAD',
+      author: signature,
+      committer: signature,
+      parents: [mainOid, featureOid],
+    });
+
+    const mergeCommit = repo.getCommit(mergeOid);
+
+    expect(() => {
+      repo.revert(mergeCommit);
+    }).toThrow();
+  });
+
+  it('should revert file addition', async () => {
+    const p = await useFixture('empty');
+    const repo = await openRepository(p);
+
+    await fs.writeFile(path.join(p, 'existing.txt'), 'existing file');
+    let index = repo.index();
+    index.addPath('existing.txt');
+    const baseTreeId = index.writeTree();
+    const baseTree = repo.getTree(baseTreeId);
+    const baseOid = repo.commit(baseTree, 'base', {
+      updateRef: 'HEAD',
+      author: signature,
+      committer: signature,
+      parents: [repo.head().target()!],
+    });
+
+    await fs.writeFile(path.join(p, 'added.txt'), 'new file content');
+    index = repo.index();
+    index.addPath('added.txt');
+    const addTreeId = index.writeTree();
+    const addTree = repo.getTree(addTreeId);
+    const addOid = repo.commit(addTree, 'add new file', {
+      updateRef: 'HEAD',
+      author: signature,
+      committer: signature,
+      parents: [baseOid],
+    });
+
+    const commitToRevert = repo.getCommit(addOid);
+    repo.revert(commitToRevert);
+
+    repo.cleanupState();
+
+    const fileExists = await fs
+      .access(path.join(p, 'added.txt'))
+      .then(() => true)
+      .catch(() => false);
+    expect(fileExists).toBe(false);
+
+    const existingFileContent = await fs.readFile(path.join(p, 'existing.txt'), 'utf-8');
+    expect(existingFileContent).toBe('existing file');
+  });
+
+  it('should revert file deletion', async () => {
+    const p = await useFixture('empty');
+    const repo = await openRepository(p);
+
+    await fs.writeFile(path.join(p, 'to-delete.txt'), 'file to be deleted');
+    let index = repo.index();
+    index.addPath('to-delete.txt');
+    const baseTreeId = index.writeTree();
+    const baseTree = repo.getTree(baseTreeId);
+    const baseOid = repo.commit(baseTree, 'base with file', {
+      updateRef: 'HEAD',
+      author: signature,
+      committer: signature,
+      parents: [repo.head().target()!],
+    });
+
+    await fs.unlink(path.join(p, 'to-delete.txt'));
+    index = repo.index();
+    index.removePath('to-delete.txt');
+    const deleteTreeId = index.writeTree();
+    const deleteTree = repo.getTree(deleteTreeId);
+    const deleteOid = repo.commit(deleteTree, 'delete file', {
+      updateRef: 'HEAD',
+      author: signature,
+      committer: signature,
+      parents: [baseOid],
+    });
+
+    const commitToRevert = repo.getCommit(deleteOid);
+    repo.revert(commitToRevert);
+
+    repo.cleanupState();
+
+    const fileContent = await fs.readFile(path.join(p, 'to-delete.txt'), 'utf-8');
+    expect(fileContent).toBe('file to be deleted');
+  });
+});


### PR DESCRIPTION
This PR implements revert features.

## Specifications

### 1. `repo.revert(commit, options?)`
Reverts the given commit, producing changes in the index and working directory.

#### Parameters
- `commit`: The commit to revert
- `options` (optional): Configuration object
  - `mainline`: Specify mainline parent for merge commit reverts
  - `mergeOptions.failOnConflict`: Whether to fail on conflict (boolean)
  - `checkoutOptions`: Additional checkout configuration

---

### 2. `repo.revertCommit(revertCommit, ourCommit, mainline, mergeOptions?)`
Reverts the given commit against the given "our" commit, producing an index that reflects the result of the revert.

#### Parameters
- `revertCommit`: The commit to be reverted
- `ourCommit`: The current commit
- `mainline`: Mainline parent number (0 for regular commits)
- `mergeOptions` (optional): Merge configuration options

---

closes #130 

