### PR TITLE
fix: complete truncated doc comment for `targetPeel` method

### DIFF
--- a/src/reference.rs
+++ b/src/reference.rs
@@ -331,7 +331,8 @@ impl Reference {
   #[napi]
   /// Return the peeled OID target of this reference.
   ///
-  /// This peeled OID only applies to direct references that point to a hard.
+  /// This peeled OID only applies to direct references that point to a hard
+  /// Tag object: it is the result of peeling such Tag.
   ///
   /// @category Reference/Methods
   /// @signature


### PR DESCRIPTION
Fix truncated doc comment for `Reference.targetPeel()` — restore missing text from [git2-rs upstream](https://github.com/rust-lang/git2-rs/blob/master/src/reference.rs).