### PR TITLE
feat: add remote callbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -83,19 +83,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "ctor"
-version = "0.6.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffc71fcdcdb40d6f087edddf7f8f1f8f79e6cf922f555a9ee8779752d4819bd"
-dependencies = [
- "ctor-proc-macro",
- "dtor",
-]
-
-[[package]]
-name = "ctor-proc-macro"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
+checksum = "400a21f1014a968ec518c7ccdf9b4a4ed0cac8c56ccb6d604f8b91f00110501e"
 
 [[package]]
 name = "displaydoc"
@@ -107,21 +97,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "dtor"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "404d02eeb088a82cfd873006cb713fe411306c7d182c344905e101fb1167d301"
-dependencies = [
- "dtor-proc-macro",
-]
-
-[[package]]
-name = "dtor-proc-macro"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "es-git"
@@ -506,9 +481,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "napi"
-version = "3.8.1"
+version = "3.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "000f205daae6646003fdc38517be6232af2b150bad4b67bdaf4c5aadb119d738"
+checksum = "8e55037284865448ecf329baa86a4d05401f647ebde99f5747b640d32c2c5226"
 dependencies = [
  "bitflags",
  "chrono",
@@ -528,9 +503,9 @@ checksum = "d376940fd5b723c6893cd1ee3f33abbfd86acb1cd1ec079f3ab04a2a3bc4d3b1"
 
 [[package]]
 name = "napi-derive"
-version = "3.3.0"
+version = "3.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78665d6bdf10e9a4e6b38123efb0f66962e6197c1aea2f07cff3f159a374696d"
+checksum = "a4ba740fe4c9524d86fd90798fd8ccdb23402b3eef7e7c30897a8a369b529fcf"
 dependencies = [
  "convert_case",
  "ctor",
@@ -542,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "3.0.0"
+version = "5.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d55d01423e7264de3acc13b258fa48ca7cf38a4d25db848908ec3c1304a85a"
+checksum = "0d5af30503edf933ce7377cf6d4c877a62b0f1107ea05585f1b5e430e88d5baf"
 dependencies = [
  "convert_case",
  "proc-macro2",

--- a/index.d.ts
+++ b/index.d.ts
@@ -8612,24 +8612,20 @@ export interface Refspec {
 }
 
 export interface RemoteCallbacks {
-  /**
-   * Called with transfer progress during fetch.
-   *
-   * Return `false` to cancel the operation.
-   */
-  transferProgress?: (data: RemoteTransferProgress) => boolean
+  /** Called with transfer progress during fetch. */
+  transferProgress?: (data: RemoteTransferProgress) => void
   /**
    * Textual progress from the remote.
    *
    * Text sent over the progress side-band will be passed to this function
    * (this is the 'counting objects' output).
    */
-  sidebandProgress?: (data: Uint8Array) => boolean
+  sidebandProgress?: (data: Uint8Array) => void
   /**
    * Each time a reference is updated locally, the callback will be called
    * with information about it.
    */
-  updateTips?: (refname: string, oldId: string, newId: string) => boolean
+  updateTips?: (refname: string, oldId: string, newId: string) => void
   /**
    * Set a callback to get invoked for each updated reference on a push.
    *
@@ -8652,8 +8648,6 @@ export interface RemoteCallbacks {
    *
    * The argument to the callback is a slice containing the updates which
    * will be sent as commands to the destination.
-   *
-   * TODO: Improved to allow throwing git2 errors
    */
   pushNegotiation?: (update: PushUpdate[]) => void
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -2288,7 +2288,8 @@ export declare class Reference {
   /**
    * Return the peeled OID target of this reference.
    *
-   * This peeled OID only applies to direct references that point to a hard.
+   * This peeled OID only applies to direct references that point to a hard
+   * Tag object: it is the result of peeling such Tag.
    *
    * @category Reference/Methods
    * @signature
@@ -7636,6 +7637,7 @@ export interface ExtractedSignature {
 
 export interface FetchOptions {
   credential?: Credential
+  callbacks?: RemoteCallbacks
   /** Set the proxy options to use for the fetch operation. */
   proxy?: ProxyOptions
   /** Set whether to perform a prune after the fetch. */
@@ -8362,6 +8364,9 @@ export declare function openRepositoryFromWorktree(worktree: Worktree): Reposito
  */
 export declare function openWorktreeFromRepository(repo: Repository): Worktree
 
+export type PackBuilderStage =  'adding_objects'|
+'deltafication';
+
 /**
  * Parse a string as a bool.
  *
@@ -8429,6 +8434,7 @@ export interface PruneOptions {
 /** Options to control the behavior of a git push. */
 export interface PushOptions {
   credential?: Credential
+  callbacks?: RemoteCallbacks
   /** Set the proxy options to use for the push operation. */
   proxy?: ProxyOptions
   /**
@@ -8452,6 +8458,17 @@ export interface PushOptions {
   customHeaders?: Array<string>
   /** Set "push options" to deliver to the remote. */
   remoteOptions?: Array<string>
+}
+
+export interface PushUpdate {
+  /** The source name of the reference, or `null` if it is not valid UTF-8. */
+  srcRefname?: string
+  /** The name of the reference to update on the server, or `null` if it is not valid UTF-8. */
+  dstRefname?: string
+  /** The current target oid of the reference. */
+  src: string
+  /** The new target oid for the reference. */
+  dst: string
 }
 
 export interface RebaseCommitOptions {
@@ -8594,6 +8611,53 @@ export interface Refspec {
   force: boolean
 }
 
+export interface RemoteCallbacks {
+  /**
+   * Called with transfer progress during fetch.
+   *
+   * Return `false` to cancel the operation.
+   */
+  transferProgress?: (data: RemoteTransferProgress) => boolean
+  /**
+   * Textual progress from the remote.
+   *
+   * Text sent over the progress side-band will be passed to this function
+   * (this is the 'counting objects' output).
+   */
+  sidebandProgress?: (data: Uint8Array) => boolean
+  /**
+   * Each time a reference is updated locally, the callback will be called
+   * with information about it.
+   */
+  updateTips?: (refname: string, oldId: string, newId: string) => boolean
+  /**
+   * Set a callback to get invoked for each updated reference on a push.
+   *
+   * The first argument to the callback is the name of the reference and the
+   * second is a status message sent by the server. If the status is not `null`
+   * then the push was rejected.
+   */
+  pushUpdateReference?: (refname: string, status: string | null) => void
+  /** The callback through which progress of push transfer is monitored */
+  pushTransferProgress?: (current: number, total: number, bytes: number) => void
+  /**
+   * Function to call with progress information during pack building.
+   *
+   * Be aware that this is called inline with pack building operations,
+   * so performance may be affected.
+   */
+  packProgress?: (stage: PackBuilderStage, current: number, total: number) => void
+  /**
+   * The callback is called once between the negotiation step and the upload.
+   *
+   * The argument to the callback is a slice containing the updates which
+   * will be sent as commands to the destination.
+   *
+   * TODO: Improved to allow throwing git2 errors
+   */
+  pushNegotiation?: (update: PushUpdate[]) => void
+}
+
 /**
  * - `None` : Do not follow any off-site redirects at any stage of the fetch or push.
  * - `Initial` : Allow off-site redirects only upon the initial request. This is the default.
@@ -8602,6 +8666,16 @@ export interface Refspec {
 export type RemoteRedirect =  'None'|
 'Initial'|
 'All';
+
+export interface RemoteTransferProgress {
+  totalObjects: number
+  indexedObjects: number
+  receivedObjects: number
+  localObjects: number
+  totalDeltas: number
+  indexedDeltas: number
+  receivedBytes: number
+}
 
 export interface RenameReferenceOptions {
   /**

--- a/index.js
+++ b/index.js
@@ -650,6 +650,7 @@ module.exports.openDefaultConfig = nativeBinding.openDefaultConfig
 module.exports.openRepository = nativeBinding.openRepository
 module.exports.openRepositoryFromWorktree = nativeBinding.openRepositoryFromWorktree
 module.exports.openWorktreeFromRepository = nativeBinding.openWorktreeFromRepository
+module.exports.PackBuilderStage = nativeBinding.PackBuilderStage
 module.exports.parseConfigBool = nativeBinding.parseConfigBool
 module.exports.parseConfigI32 = nativeBinding.parseConfigI32
 module.exports.parseConfigI64 = nativeBinding.parseConfigI64

--- a/src/js.rs
+++ b/src/js.rs
@@ -1,59 +1,23 @@
-/// Source codes are from [rolldown](https://github.com/rolldown/rolldown)
-/// See: https://github.com/rolldown/rolldown/blob/fc5ec4dbb8cf7a9bc32f2cba6e0e82eba3ac888d/crates/rolldown_binding/src/types/js_callback.rs#L98
-use napi::bindgen_prelude::{FromNapiValue, JsValuesTupleIntoVec};
-use napi::threadsafe_function::{ThreadsafeFunction, UnknownReturnValue};
-use napi::{Either, Error, Status};
-use std::sync::{Arc, Condvar, Mutex};
+use napi::bindgen_prelude::JsValuesTupleIntoVec;
+use napi::threadsafe_function::ThreadsafeFunction;
+use napi::{Error, Status};
+use std::sync::Arc;
 
-pub type JsCallback<Args = (), Ret = ()> =
-  Arc<ThreadsafeFunction<Args, Either<Ret, UnknownReturnValue>, Args, Status, false, true>>;
+pub type JsCallback<Args = ()> = Arc<ThreadsafeFunction<Args, (), Args, Status, false, true>>;
 
-pub trait JsCallbackExt<Args, Ret> {
-  fn invoke(&self, args: Args) -> Result<Ret, Error>;
+pub trait JsCallbackExt<Args> {
+  fn invoke(&self, args: Args) -> Result<(), Error>;
 }
 
-impl<Args, Ret> JsCallbackExt<Args, Ret> for JsCallback<Args, Ret>
+impl<Args> JsCallbackExt<Args> for JsCallback<Args>
 where
   Args: 'static + Send + JsValuesTupleIntoVec,
-  Ret: 'static + Send + FromNapiValue,
-  Either<Ret, UnknownReturnValue>: FromNapiValue,
 {
-  fn invoke(&self, args: Args) -> Result<Ret, Error> {
-    let init_value = Ok(Either::B(UnknownReturnValue));
-    let pair = Arc::new((Mutex::new(init_value), Condvar::new()));
-    let pair_clone = Arc::clone(&pair);
-
-    self.call_with_return_value(
-      args,
-      napi::threadsafe_function::ThreadsafeFunctionCallMode::NonBlocking,
-      move |ret, _env| {
-        let (lock, cvar) = &*pair;
-        *lock.lock().unwrap() = ret;
-        cvar.notify_one();
-        Ok(())
-      },
-    );
-
-    let (lock, cvar) = &*pair_clone;
-    let notified = lock.lock().unwrap();
-    let mut res = cvar
-      .wait(notified)
-      .map_err(|err| Error::new(Status::GenericFailure, format!("PoisonError: {err:?}",)))?;
-    let res = res
-      .as_mut()
-      .map_err(|err| Error::new(Status::GenericFailure, format!("{err:?}",)))?;
-
-    match std::mem::replace(res, Either::B(UnknownReturnValue)) {
-      Either::A(ret) => Ok(ret),
-      Either::B(_unknown) => unknown_return_err::<Ret>(),
+  fn invoke(&self, args: Args) -> Result<(), Error> {
+    let status = self.call(args, napi::threadsafe_function::ThreadsafeFunctionCallMode::NonBlocking);
+    if status != Status::Ok {
+      return Err(Error::from_status(status));
     }
+    Ok(())
   }
-}
-
-fn unknown_return_err<Ret>() -> Result<Ret, Error> {
-  let js_type = "unknown";
-  Err(Error::new(
-    Status::InvalidArg,
-    format!("UNKNOWN_RETURN_VALUE. Cannot convert {js_type}"),
-  ))
 }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,3 +1,4 @@
+use crate::js::{JsCallback, JsCallbackExt};
 use crate::repository::Repository;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
@@ -197,8 +198,130 @@ impl From<RemoteRedirect> for git2::RemoteRedirect {
 }
 
 #[napi(object)]
+pub struct RemoteTransferProgress {
+  pub total_objects: u32,
+  pub indexed_objects: u32,
+  pub received_objects: u32,
+  pub local_objects: u32,
+  pub total_deltas: u32,
+  pub indexed_deltas: u32,
+  pub received_bytes: u32,
+}
+
+impl From<git2::Progress<'_>> for RemoteTransferProgress {
+  fn from(progress: git2::Progress<'_>) -> Self {
+    Self {
+      total_objects: progress.total_objects() as u32,
+      indexed_objects: progress.indexed_objects() as u32,
+      received_objects: progress.received_objects() as u32,
+      local_objects: progress.local_objects() as u32,
+      total_deltas: progress.total_deltas() as u32,
+      indexed_deltas: progress.indexed_deltas() as u32,
+      received_bytes: progress.received_bytes() as u32,
+    }
+  }
+}
+
+#[napi(string_enum = "snake_case")]
+pub enum PackBuilderStage {
+  AddingObjects,
+  Deltafication,
+}
+
+impl From<git2::PackBuilderStage> for PackBuilderStage {
+  fn from(stage: git2::PackBuilderStage) -> Self {
+    match stage {
+      git2::PackBuilderStage::AddingObjects => PackBuilderStage::AddingObjects,
+      git2::PackBuilderStage::Deltafication => PackBuilderStage::Deltafication,
+    }
+  }
+}
+
+#[napi(object)]
+pub struct PushUpdate {
+  /// The source name of the reference, or `null` if it is not valid UTF-8.
+  pub src_refname: Option<String>,
+  /// The name of the reference to update on the server, or `null` if it is not valid UTF-8.
+  pub dst_refname: Option<String>,
+  /// The current target oid of the reference.
+  pub src: String,
+  /// The new target oid for the reference.
+  pub dst: String,
+}
+
+impl From<&git2::PushUpdate<'_>> for PushUpdate {
+  fn from(update: &git2::PushUpdate<'_>) -> Self {
+    let src_refname = std::str::from_utf8(update.src_refname_bytes())
+      .ok()
+      .map(|x| x.to_string());
+    let dst_refname = std::str::from_utf8(update.dst_refname_bytes())
+      .ok()
+      .map(|x| x.to_string());
+    Self {
+      src_refname,
+      dst_refname,
+      src: update.src().to_string(),
+      dst: update.dst().to_string(),
+    }
+  }
+}
+
+pub type TransferProgress = JsCallback<RemoteTransferProgress, bool>;
+pub type SidebandProgress = JsCallback<Uint8Array, bool>;
+pub type UpdateTips = JsCallback<FnArgs<(String, String, String)>, bool>;
+pub type PushUpdateReference = JsCallback<FnArgs<(String, Option<String>)>>;
+pub type PushTransferProgress = JsCallback<FnArgs<(u32, u32, u32)>>;
+pub type PackProgress = JsCallback<FnArgs<(PackBuilderStage, u32, u32)>>;
+pub type PushNegotiation = JsCallback<Vec<PushUpdate>>;
+
+#[napi(object, object_to_js = false)]
+pub struct RemoteCallbacks {
+  /// Called with transfer progress during fetch.
+  ///
+  /// Return `false` to cancel the operation.
+  #[napi(ts_type = "(data: RemoteTransferProgress) => boolean")]
+  pub transfer_progress: Option<TransferProgress>,
+  /// Textual progress from the remote.
+  ///
+  /// Text sent over the progress side-band will be passed to this function
+  /// (this is the 'counting objects' output).
+  #[napi(ts_type = "(data: Uint8Array) => boolean")]
+  pub sideband_progress: Option<SidebandProgress>,
+  /// Each time a reference is updated locally, the callback will be called
+  /// with information about it.
+  #[napi(ts_type = "(refname: string, oldId: string, newId: string) => boolean")]
+  pub update_tips: Option<UpdateTips>,
+  // TODO: certificate_check
+  /// Set a callback to get invoked for each updated reference on a push.
+  ///
+  /// The first argument to the callback is the name of the reference and the
+  /// second is a status message sent by the server. If the status is not `null`
+  /// then the push was rejected.
+  #[napi(ts_type = "(refname: string, status: string | null) => void")]
+  pub push_update_reference: Option<PushUpdateReference>,
+  /// The callback through which progress of push transfer is monitored
+  #[napi(ts_type = "(current: number, total: number, bytes: number) => void")]
+  pub push_transfer_progress: Option<PushTransferProgress>,
+  /// Function to call with progress information during pack building.
+  ///
+  /// Be aware that this is called inline with pack building operations,
+  /// so performance may be affected.
+  #[napi(ts_type = "(stage: PackBuilderStage, current: number, total: number) => void")]
+  pub pack_progress: Option<PackProgress>,
+  /// The callback is called once between the negotiation step and the upload.
+  ///
+  /// The argument to the callback is a slice containing the updates which
+  /// will be sent as commands to the destination.
+  ///
+  /// TODO: Improved to allow throwing git2 errors
+  #[napi(ts_type = "(update: PushUpdate[]) => void")]
+  pub push_negotiation: Option<PushNegotiation>,
+}
+
+#[napi(object, object_to_js = false)]
 pub struct FetchOptions {
   pub credential: Option<Credential>,
+  pub callbacks: Option<RemoteCallbacks>,
   /// Set the proxy options to use for the fetch operation.
   pub proxy: Option<ProxyOptions>,
   /// Set whether to perform a prune after the fetch.
@@ -221,12 +344,78 @@ pub struct FetchOptions {
   pub custom_headers: Option<Vec<String>>,
 }
 
+trait ApplyRemoteCallbacks {
+  fn apply(&mut self, cbs: &RemoteCallbacks) -> &mut Self;
+}
+
+impl<'a> ApplyRemoteCallbacks for git2::RemoteCallbacks<'a> {
+  fn apply(&mut self, cbs: &RemoteCallbacks) -> &mut Self {
+    if let Some(cb) = &cbs.transfer_progress {
+      self.transfer_progress({
+        let cb = cb.clone();
+        move |progress| cb.invoke(RemoteTransferProgress::from(progress)).unwrap_or(false)
+      });
+    }
+    if let Some(cb) = &cbs.sideband_progress {
+      self.sideband_progress({
+        let cb = cb.clone();
+        move |data| cb.invoke(Uint8Array::from(data)).unwrap_or(false)
+      });
+    }
+    if let Some(cb) = &cbs.update_tips {
+      self.update_tips({
+        let cb = cb.clone();
+        move |refname, old_oid, new_oid| {
+          let refname = refname.to_string();
+          let old_oid = old_oid.to_string();
+          let new_oid = new_oid.to_string();
+          cb.invoke((refname, old_oid, new_oid).into()).unwrap_or(false)
+        }
+      });
+    }
+    if let Some(cb) = &cbs.push_update_reference {
+      self.push_update_reference({
+        let cb = cb.clone();
+        move |refname, status| {
+          let _ = cb.invoke((refname.to_string(), status.map(|x| x.to_string())).into());
+          Ok(())
+        }
+      });
+    }
+    if let Some(cb) = &cbs.push_transfer_progress {
+      let cb = cb.clone();
+      self.push_transfer_progress(move |current, total, bytes| {
+        let _ = cb.invoke((current as u32, total as u32, bytes as u32).into());
+      });
+    }
+    if let Some(cb) = &cbs.pack_progress {
+      let cb = cb.clone();
+      self.pack_progress(move |stage, current, total| {
+        let _ = cb.invoke((stage.into(), current as u32, total as u32).into());
+      });
+    }
+    if let Some(cb) = &cbs.push_negotiation {
+      let cb = cb.clone();
+      self.push_negotiation(move |update| {
+        let updates = update.iter().map(PushUpdate::from).collect::<Vec<_>>();
+        let _ = cb.invoke(updates);
+        Ok(())
+      });
+    }
+    self
+  }
+}
+
 impl<'a> FetchOptions {
   pub(crate) fn to_git2_fetch_options(&'a self) -> git2::FetchOptions<'a> {
     let mut fetch = git2::FetchOptions::new();
     let mut callbacks = git2::RemoteCallbacks::new();
     if let Some(cred) = &self.credential {
+      // TODO: support credential callback
       callbacks.credentials(move |_url, _username, _cred| cred.to_git2_cred());
+    }
+    if let Some(cbs) = &self.callbacks {
+      callbacks.apply(cbs);
     }
     fetch.remote_callbacks(callbacks);
     if let Some(proxy) = &self.proxy {
@@ -251,10 +440,11 @@ impl<'a> FetchOptions {
   }
 }
 
-#[napi(object)]
+#[napi(object, object_to_js = false)]
 /// Options to control the behavior of a git push.
 pub struct PushOptions {
   pub credential: Option<Credential>,
+  pub callbacks: Option<RemoteCallbacks>,
   /// Set the proxy options to use for the push operation.
   pub proxy: Option<ProxyOptions>,
   /// If the transport being used to push to the remote requires the creation
@@ -281,7 +471,11 @@ impl<'a> PushOptions {
     let mut push = git2::PushOptions::new();
     let mut callbacks = git2::RemoteCallbacks::new();
     if let Some(cred) = &self.credential {
+      // TODO: support credential callback
       callbacks.credentials(move |_url, _username, _cred| cred.to_git2_cred());
+    }
+    if let Some(cbs) = &self.callbacks {
+      callbacks.apply(cbs);
     }
     push.remote_callbacks(callbacks);
     if let Some(proxy) = &self.proxy {
@@ -308,7 +502,7 @@ pub struct CreateRemoteOptions {
   pub fetch_refspec: Option<String>,
 }
 
-#[napi(object)]
+#[napi(object, object_to_js = false)]
 pub struct FetchRemoteOptions {
   /// Options which can be specified to various fetch operations.
   pub fetch: Option<FetchOptions>,

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -266,9 +266,9 @@ impl From<&git2::PushUpdate<'_>> for PushUpdate {
   }
 }
 
-pub type TransferProgress = JsCallback<RemoteTransferProgress, bool>;
-pub type SidebandProgress = JsCallback<Uint8Array, bool>;
-pub type UpdateTips = JsCallback<FnArgs<(String, String, String)>, bool>;
+pub type TransferProgress = JsCallback<RemoteTransferProgress>;
+pub type SidebandProgress = JsCallback<Uint8Array>;
+pub type UpdateTips = JsCallback<FnArgs<(String, String, String)>>;
 pub type PushUpdateReference = JsCallback<FnArgs<(String, Option<String>)>>;
 pub type PushTransferProgress = JsCallback<FnArgs<(u32, u32, u32)>>;
 pub type PackProgress = JsCallback<FnArgs<(PackBuilderStage, u32, u32)>>;
@@ -277,19 +277,17 @@ pub type PushNegotiation = JsCallback<Vec<PushUpdate>>;
 #[napi(object, object_to_js = false)]
 pub struct RemoteCallbacks {
   /// Called with transfer progress during fetch.
-  ///
-  /// Return `false` to cancel the operation.
-  #[napi(ts_type = "(data: RemoteTransferProgress) => boolean")]
+  #[napi(ts_type = "(data: RemoteTransferProgress) => void")]
   pub transfer_progress: Option<TransferProgress>,
   /// Textual progress from the remote.
   ///
   /// Text sent over the progress side-band will be passed to this function
   /// (this is the 'counting objects' output).
-  #[napi(ts_type = "(data: Uint8Array) => boolean")]
+  #[napi(ts_type = "(data: Uint8Array) => void")]
   pub sideband_progress: Option<SidebandProgress>,
   /// Each time a reference is updated locally, the callback will be called
   /// with information about it.
-  #[napi(ts_type = "(refname: string, oldId: string, newId: string) => boolean")]
+  #[napi(ts_type = "(refname: string, oldId: string, newId: string) => void")]
   pub update_tips: Option<UpdateTips>,
   // TODO: certificate_check
   /// Set a callback to get invoked for each updated reference on a push.
@@ -312,8 +310,6 @@ pub struct RemoteCallbacks {
   ///
   /// The argument to the callback is a slice containing the updates which
   /// will be sent as commands to the destination.
-  ///
-  /// TODO: Improved to allow throwing git2 errors
   #[napi(ts_type = "(update: PushUpdate[]) => void")]
   pub push_negotiation: Option<PushNegotiation>,
 }
@@ -353,13 +349,19 @@ impl<'a> ApplyRemoteCallbacks for git2::RemoteCallbacks<'a> {
     if let Some(cb) = &cbs.transfer_progress {
       self.transfer_progress({
         let cb = cb.clone();
-        move |progress| cb.invoke(RemoteTransferProgress::from(progress)).unwrap_or(false)
+        move |progress| {
+          let _ = cb.invoke(RemoteTransferProgress::from(progress));
+          true
+        }
       });
     }
     if let Some(cb) = &cbs.sideband_progress {
       self.sideband_progress({
         let cb = cb.clone();
-        move |data| cb.invoke(Uint8Array::from(data)).unwrap_or(false)
+        move |data| {
+          let _ = cb.invoke(Uint8Array::from(data));
+          true
+        }
       });
     }
     if let Some(cb) = &cbs.update_tips {
@@ -369,7 +371,8 @@ impl<'a> ApplyRemoteCallbacks for git2::RemoteCallbacks<'a> {
           let refname = refname.to_string();
           let old_oid = old_oid.to_string();
           let new_oid = new_oid.to_string();
-          cb.invoke((refname, old_oid, new_oid).into()).unwrap_or(false)
+          let _ = cb.invoke((refname, old_oid, new_oid).into());
+          true
         }
       });
     }

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -210,7 +210,7 @@ impl RepositoryOpenOptions {
   }
 }
 
-#[napi(object)]
+#[napi(object, object_to_js = false)]
 pub struct RepositoryCloneOptions {
   /// Indicate whether the repository will be cloned as a bare repository or
   /// not.

--- a/tests/remote.spec.ts
+++ b/tests/remote.spec.ts
@@ -87,7 +87,7 @@ describe('remote', () => {
 
     const remote = localRepo.createRemote('origin', remotePath);
     const localHead = localRepo.head().target()!;
-    const updateTips = vi.fn().mockImplementation(() => true);
+    const updateTips = vi.fn();
     const pushUpdateReference = vi.fn();
     const pushTransferProgress = vi.fn();
     const pushNegotiation = vi.fn();
@@ -104,20 +104,22 @@ describe('remote', () => {
     });
 
     expect(remoteRepo.getReference('refs/heads/main').target()).toEqual(localHead);
-    expect(updateTips).toHaveBeenCalledWith(
-      'refs/remotes/origin/main',
-      '0000000000000000000000000000000000000000',
-      localHead
-    );
-    expect(pushUpdateReference).toHaveBeenCalledWith('refs/heads/main', null);
-    expect(pushNegotiation).toHaveBeenCalledWith([
-      {
-        src: '0000000000000000000000000000000000000000',
-        dst: localHead,
-        srcRefname: 'refs/heads/main',
-        dstRefname: 'refs/heads/main',
-      },
-    ]);
-    expect(packProgress).toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(updateTips).toHaveBeenCalledWith(
+        'refs/remotes/origin/main',
+        '0000000000000000000000000000000000000000',
+        localHead
+      );
+      expect(pushUpdateReference).toHaveBeenCalledWith('refs/heads/main', null);
+      expect(pushNegotiation).toHaveBeenCalledWith([
+        {
+          src: '0000000000000000000000000000000000000000',
+          dst: localHead,
+          srcRefname: 'refs/heads/main',
+          dstRefname: 'refs/heads/main',
+        },
+      ]);
+      expect(packProgress).toHaveBeenCalled();
+    });
   });
 });

--- a/tests/remote.spec.ts
+++ b/tests/remote.spec.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { cloneRepository, openRepository } from '../index';
+import { describe, expect, it, vi } from 'vitest';
+import { cloneRepository, initRepository, openRepository } from '../index';
 import { isTarget } from './env';
 import { useFixture } from './fixtures';
 import { makeTmpDir } from './tmp';
@@ -49,5 +49,75 @@ describe('remote', () => {
     const remote = repo.getRemote('origin');
     const branch = await remote.defaultBranch();
     expect(branch).toEqual('refs/heads/main');
+  });
+
+  it('push remote to local bare repository', async () => {
+    const localPath = await useFixture('commits');
+    const remotePath = await makeTmpDir('remote-bare');
+    const localRepo = await openRepository(localPath);
+    const remoteRepo = await initRepository(remotePath, { bare: true });
+
+    const remote = localRepo.createRemote('origin', remotePath);
+    const localHead = localRepo.head().target()!;
+
+    await remote.push(['refs/heads/main:refs/heads/main']);
+
+    expect(remoteRepo.getReference('refs/heads/main').target()).toEqual(localHead);
+  });
+
+  it('push remote with explicit refspec', async () => {
+    const localPath = await useFixture('commits');
+    const remotePath = await makeTmpDir('remote-bare');
+    const localRepo = await openRepository(localPath);
+    const remoteRepo = await initRepository(remotePath, { bare: true });
+
+    const remote = localRepo.createRemote('origin', remotePath);
+    const localHead = localRepo.head().target()!;
+
+    await remote.push(['refs/heads/main:refs/heads/pushed-main']);
+
+    expect(remoteRepo.getReference('refs/heads/pushed-main').target()).toEqual(localHead);
+  });
+
+  it('push remote with callbacks', async () => {
+    const localPath = await useFixture('commits');
+    const remotePath = await makeTmpDir('remote-bare');
+    const localRepo = await openRepository(localPath);
+    const remoteRepo = await initRepository(remotePath, { bare: true });
+
+    const remote = localRepo.createRemote('origin', remotePath);
+    const localHead = localRepo.head().target()!;
+    const updateTips = vi.fn().mockImplementation(() => true);
+    const pushUpdateReference = vi.fn();
+    const pushTransferProgress = vi.fn();
+    const pushNegotiation = vi.fn();
+    const packProgress = vi.fn();
+
+    await remote.push(['refs/heads/main:refs/heads/main'], {
+      callbacks: {
+        updateTips,
+        pushUpdateReference,
+        pushTransferProgress,
+        pushNegotiation,
+        packProgress,
+      },
+    });
+
+    expect(remoteRepo.getReference('refs/heads/main').target()).toEqual(localHead);
+    expect(updateTips).toHaveBeenCalledWith(
+      'refs/remotes/origin/main',
+      '0000000000000000000000000000000000000000',
+      localHead
+    );
+    expect(pushUpdateReference).toHaveBeenCalledWith('refs/heads/main', null);
+    expect(pushNegotiation).toHaveBeenCalledWith([
+      {
+        src: '0000000000000000000000000000000000000000',
+        dst: localHead,
+        srcRefname: 'refs/heads/main',
+        dstRefname: 'refs/heads/main',
+      },
+    ]);
+    expect(packProgress).toHaveBeenCalled();
   });
 });

--- a/tests/repository.spec.ts
+++ b/tests/repository.spec.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { cloneRepository, initRepository, openRepository } from '../index';
 import { isTarget } from './env';
 import { useFixture } from './fixtures';
@@ -56,6 +56,37 @@ describe('Repository', () => {
     const repo = await cloneRepository('https://github.com/seokju-na/dummy-repo', p);
     expect(repo.state()).toBe('Clean');
   });
+
+  it('clone from remote with callbacks', { skip: isTarget('linux', undefined, 'gnu') }, async () => {
+    const p = await makeTmpDir('clone');
+    const transferProgress = vi.fn().mockImplementation(() => true);
+    await cloneRepository('https://github.com/seokju-na/dummy-repo', p, {
+      fetch: {
+        callbacks: {
+          transferProgress,
+        },
+      },
+    });
+    expect(transferProgress).toHaveBeenCalled();
+  });
+
+  it(
+    'reject clone when transfer progress calback returns `false`',
+    { skip: isTarget('linux', undefined, 'gnu') },
+    async () => {
+      const p = await makeTmpDir('clone');
+      const transferProgress = vi.fn().mockImplementation(() => false);
+      await expect(
+        cloneRepository('https://github.com/seokju-na/dummy-repo', p, {
+          fetch: {
+            callbacks: {
+              transferProgress,
+            },
+          },
+        })
+      ).rejects.toThrowError(/progress callback returned -1/);
+    }
+  );
 
   it('get head', async () => {
     const p = await useFixture('commits');

--- a/tests/repository.spec.ts
+++ b/tests/repository.spec.ts
@@ -67,26 +67,10 @@ describe('Repository', () => {
         },
       },
     });
-    expect(transferProgress).toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(transferProgress).toHaveBeenCalled();
+    });
   });
-
-  it(
-    'reject clone when transfer progress calback returns `false`',
-    { skip: isTarget('linux', undefined, 'gnu') },
-    async () => {
-      const p = await makeTmpDir('clone');
-      const transferProgress = vi.fn().mockImplementation(() => false);
-      await expect(
-        cloneRepository('https://github.com/seokju-na/dummy-repo', p, {
-          fetch: {
-            callbacks: {
-              transferProgress,
-            },
-          },
-        })
-      ).rejects.toThrowError(/progress callback returned -1/);
-    }
-  );
 
   it('get head', async () => {
     const p = await useFixture('commits');


### PR DESCRIPTION
Add remote callbacks for fetch options.

The following tasks are scheduled to be continued in a separate PR.

- Support for JavaScript functions in credential callbacks
- Added a credential check callback
- Expose the libgit2 Error object to allow throwing errors in callbacks

See libgit2 implementation : https://libgit2.org/docs/reference/main/remote/git_remote_callbacks.html