### PR TITLE
feat(repository): expose commit signing buffer APIs

### DIFF
--- a/docs/ko/reference/Repository/Methods/commitCreateBuffer.md
+++ b/docs/ko/reference/Repository/Methods/commitCreateBuffer.md
@@ -1,0 +1,142 @@
+# commitCreateBuffer
+
+외부에서 서명할 커밋 내용을 만들어요.
+
+서명되지 않은 커밋 객체 내용을 만들지만 객체 데이터베이스에는 저장하지 않아요.
+이 메서드가 반환한 문자열의 UTF-8 바이트를 그대로 서명한 다음, 커밋 내용과 서명을
+`commitSigned()`에 전달하세요. 서명한 뒤 공백이나 줄바꿈을 변경하면 서명이 유효하지 않게 돼요.
+
+## 시그니처
+
+```ts
+class Repository {
+  commitCreateBuffer(
+    tree: Tree,
+    message: string,
+    options?: CommitCreateBufferOptions | null | undefined,
+  ): string;
+}
+```
+
+### 파라미터
+
+<ul class="param-ul">
+  <li class="param-li param-li-root">
+    <span class="param-name">tree</span><span class="param-required">필수</span>&nbsp;·&nbsp;<span class="param-type">Tree</span>
+    <br>
+    <p class="param-description">커밋 내용을 만들 트리예요.</p>
+  </li>
+  <li class="param-li param-li-root">
+    <span class="param-name">message</span><span class="param-required">필수</span>&nbsp;·&nbsp;<span class="param-type">string</span>
+    <br>
+    <p class="param-description">커밋 메시지예요.</p>
+  </li>
+  <li class="param-li param-li-root">
+    <span class="param-name">options</span><span class="param-type">CommitCreateBufferOptions | null</span>
+    <br>
+    <p class="param-description">커밋 내용 생성 옵션이에요.</p>
+    <ul class="param-ul">
+      <li class="param-li">
+        <span class="param-name">author</span><span class="param-type">SignaturePayload</span>
+        <br>
+        <p class="param-description">작성자 서명이에요. 지정하지 않으면 리포지토리의 기본 서명을 사용해요. 기본 서명이 없으면 오류가 발생해요.</p>
+        <ul class="param-ul">
+          <li class="param-li">
+            <span class="param-name">email</span><span class="param-required">필수</span>&nbsp;·&nbsp;<span class="param-type">string</span>
+            <br>
+            <p class="param-description">서명에 사용할 이메일 주소예요.</p>
+          </li>
+          <li class="param-li">
+            <span class="param-name">name</span><span class="param-required">필수</span>&nbsp;·&nbsp;<span class="param-type">string</span>
+            <br>
+            <p class="param-description">서명에 사용할 이름이에요.</p>
+          </li>
+          <li class="param-li">
+            <span class="param-name">timeOptions</span><span class="param-type">SignatureTimeOptions</span>
+            <br>
+            <ul class="param-ul">
+              <li class="param-li">
+                <span class="param-name">offset</span><span class="param-type">number</span>
+                <br>
+                <p class="param-description">분 단위 시간대 오프셋이에요.</p>
+              </li>
+              <li class="param-li">
+                <span class="param-name">timestamp</span><span class="param-required">필수</span>&nbsp;·&nbsp;<span class="param-type">number</span>
+                <br>
+                <p class="param-description">Unix epoch 기준 초 단위 시간이에요.</p>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li class="param-li">
+        <span class="param-name">committer</span><span class="param-type">SignaturePayload</span>
+        <br>
+        <p class="param-description">커미터 서명이에요. 지정하지 않으면 리포지토리의 기본 서명을 사용해요. 기본 서명이 없으면 오류가 발생해요.</p>
+        <ul class="param-ul">
+          <li class="param-li">
+            <span class="param-name">email</span><span class="param-required">필수</span>&nbsp;·&nbsp;<span class="param-type">string</span>
+            <br>
+            <p class="param-description">서명에 사용할 이메일 주소예요.</p>
+          </li>
+          <li class="param-li">
+            <span class="param-name">name</span><span class="param-required">필수</span>&nbsp;·&nbsp;<span class="param-type">string</span>
+            <br>
+            <p class="param-description">서명에 사용할 이름이에요.</p>
+          </li>
+          <li class="param-li">
+            <span class="param-name">timeOptions</span><span class="param-type">SignatureTimeOptions</span>
+            <br>
+            <ul class="param-ul">
+              <li class="param-li">
+                <span class="param-name">offset</span><span class="param-type">number</span>
+                <br>
+                <p class="param-description">분 단위 시간대 오프셋이에요.</p>
+              </li>
+              <li class="param-li">
+                <span class="param-name">timestamp</span><span class="param-required">필수</span>&nbsp;·&nbsp;<span class="param-type">number</span>
+                <br>
+                <p class="param-description">Unix epoch 기준 초 단위 시간이에요.</p>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li class="param-li">
+        <span class="param-name">parents</span><span class="param-type">string[]</span>
+        <br>
+        <p class="param-description">의도한 순서대로 나열한 부모 커밋 ID예요.</p>
+      </li>
+    </ul>
+  </li>
+</ul>
+
+### 반환 값
+
+<ul class="param-ul">
+  <li class="param-li param-li-root">
+    <span class="param-type">string</span>
+    <br>
+    <p class="param-description">외부에서 서명할 커밋 내용이에요.</p>
+  </li>
+</ul>
+
+### 에러
+
+<ul class="param-ul">
+  <li class="param-li param-li-root">
+    <span class="param-type">Error</span>
+    <br>
+    <p class="param-description">서명을 확인할 수 없거나 부모 커밋이 존재하지 않을 때 발생해요.</p>
+  </li>
+</ul>
+
+## 예제
+
+```ts
+const content = repo.commitCreateBuffer(tree, 'signed commit', {
+  parents: [repo.head().target()!],
+});
+const signature = await signingBackend.sign(Buffer.from(content, 'utf8'));
+const oid = repo.commitSigned(content, signature);
+```

--- a/docs/ko/reference/Repository/Methods/commitSigned.md
+++ b/docs/ko/reference/Repository/Methods/commitSigned.md
@@ -1,0 +1,54 @@
+# commitSigned
+
+외부에서 서명한 커밋 내용을 저장해요.
+
+서명된 커밋을 객체 데이터베이스에 저장하지만 `HEAD`나 다른 레퍼런스는 갱신하지 않아요.
+`signatureField`를 생략하면 Git의 기본 필드인 `gpgsig`를 사용해요.
+
+## 시그니처
+
+```ts
+class Repository {
+  commitSigned(commitContent: string, signature: string, signatureField?: string | null | undefined): string;
+}
+```
+
+### 파라미터
+
+<ul class="param-ul">
+  <li class="param-li param-li-root">
+    <span class="param-name">commitContent</span><span class="param-required">필수</span>&nbsp;·&nbsp;<span class="param-type">string</span>
+    <br>
+    <p class="param-description"><code>commitCreateBuffer()</code>가 반환한 커밋 내용이에요.</p>
+  </li>
+  <li class="param-li param-li-root">
+    <span class="param-name">signature</span><span class="param-required">필수</span>&nbsp;·&nbsp;<span class="param-type">string</span>
+    <br>
+    <p class="param-description">커밋 내용에 대한 외부 서명이에요.</p>
+  </li>
+  <li class="param-li param-li-root">
+    <span class="param-name">signatureField</span><span class="param-type">string | null</span>
+    <br>
+    <p class="param-description">서명 필드 이름이에요. 기본값은 <code>gpgsig</code>예요.</p>
+  </li>
+</ul>
+
+### 반환 값
+
+<ul class="param-ul">
+  <li class="param-li param-li-root">
+    <span class="param-type">string</span>
+    <br>
+    <p class="param-description">생성한 커밋의 ID(SHA1)예요.</p>
+  </li>
+</ul>
+
+### 에러
+
+<ul class="param-ul">
+  <li class="param-li param-li-root">
+    <span class="param-type">Error</span>
+    <br>
+    <p class="param-description">커밋 내용, 서명 또는 서명 필드가 유효하지 않을 때 발생해요.</p>
+  </li>
+</ul>

--- a/docs/ko/usage/commit.md
+++ b/docs/ko/usage/commit.md
@@ -35,7 +35,9 @@ index.write();
 
 ## 서명된 커밋 생성하기
 
-GPG 서명 문자열을 제공하여 서명된 커밋을 생성할 수 있어요:
+외부 서명은 두 단계로 진행해요. 먼저 서명되지 않은 커밋 내용을 만들고, 반환된 문자열의 UTF-8 바이트를 그대로 서명 백엔드에 전달해요. 그런 다음 반환된 서명으로 커밋을 저장해요.
+
+`commitCreateBuffer()`가 반환한 문자열의 공백이나 줄바꿈을 변경하면 서명이 유효하지 않게 돼요. `commitSigned()`는 커밋을 객체 데이터베이스에 저장하지만 `HEAD`나 다른 레퍼런스를 갱신하지 않아요.
 
 ```ts
 import { openRepository } from 'es-git';
@@ -46,26 +48,19 @@ const treeOid = index.writeTree();
 const tree = repo.getTree(treeOid);
 
 const signature = { name: 'Seokju Na', email: 'seokju.me@toss.im' };
-
-// 서명된 커밋 생성
-const oid = repo.commit(tree, 'signed commit', {
-    updateRef: 'HEAD',
-    author: signature,
-    committer: signature,
-    parents: [repo.head().target()!],
-    signature: '-----BEGIN PGP SIGNATURE-----\\nVersion: GnuPG v1\\n\\niQEcBAABAgAGBQJTest123\\n-----END PGP SIGNATURE-----'
+const commitContent = repo.commitCreateBuffer(tree, 'signed commit', {
+  author: signature,
+  committer: signature,
+  parents: [repo.head().target()!],
 });
 
-// 커밋에서 서명 추출
+// 사용하는 GPG 또는 다른 Git 호환 서명 백엔드로 이 함수를 구현하세요.
+const externalSignature = await signCommitContent(Buffer.from(commitContent, 'utf8'));
+const oid = repo.commitSigned(commitContent, externalSignature);
+
 const signatureInfo = repo.extractSignature(oid);
-console.log(signatureInfo.signature);
-// {
-//  signature: '-----BEGIN PGP SIGNATURE-----\\nVersion: GnuPG v1\\n\\niQEcBAABAgAGBQJTest123\\n-----END PGP SIGNATURE-----',
-//  signedData: 'tree ab9abf28de846b5968a8f12156f1d5ce3f4a198e\n' +
-//  'parent a01e9888e46729ef4aa68953ba19b02a7a64eb82\n' +
-//  'author Seokju Na <seokju.me@toss.im> 1744517729 +0000\n' +
-//  'committer Seokju Na <seokju.me@toss.im> 1744517729 +0000\n' +
-//  '\n' +
-//  'signed commit'
-// }
+console.log(signatureInfo?.signature === externalSignature); // true
+console.log(signatureInfo?.signedData === commitContent); // true
 ```
+
+`commit()`이 생성할 커밋 내용과 정확히 일치하는 서명이 이미 있다면 `CommitOptions.signature`로 계속 전달할 수 있어요.

--- a/docs/reference/Repository/Methods/commitCreateBuffer.md
+++ b/docs/reference/Repository/Methods/commitCreateBuffer.md
@@ -1,0 +1,143 @@
+# commitCreateBuffer
+
+Create commit content for external signing.
+
+This creates the unsigned commit object content without writing it to the
+object database. Sign the exact UTF-8 content returned by this method,
+then pass both values to `commitSigned`. Changing whitespace or line
+endings after signing invalidates the signature.
+
+## Signature
+
+```ts
+class Repository {
+  commitCreateBuffer(
+    tree: Tree,
+    message: string,
+    options?: CommitCreateBufferOptions | null | undefined,
+  ): string;
+}
+```
+
+### Parameters
+
+<ul class="param-ul">
+  <li class="param-li param-li-root">
+    <span class="param-name">tree</span><span class="param-required">required</span>&nbsp;·&nbsp;<span class="param-type">Tree</span>
+    <br>
+    <p class="param-description">Tree object to create commit content from.</p>
+  </li>
+  <li class="param-li param-li-root">
+    <span class="param-name">message</span><span class="param-required">required</span>&nbsp;·&nbsp;<span class="param-type">string</span>
+    <br>
+    <p class="param-description">Commit message.</p>
+  </li>
+  <li class="param-li param-li-root">
+    <span class="param-name">options</span><span class="param-type">CommitCreateBufferOptions | null</span>
+    <br>
+    <p class="param-description">Options for creating commit content.</p>
+    <ul class="param-ul">
+      <li class="param-li">
+        <span class="param-name">author</span><span class="param-type">SignaturePayload</span>
+        <br>
+        <p class="param-description">Signature for author.  If not provided, the default signature of the repository will be used. If there is no default signature set for the repository, an error will occur.</p>
+        <ul class="param-ul">
+          <li class="param-li">
+            <span class="param-name">email</span><span class="param-required">required</span>&nbsp;·&nbsp;<span class="param-type">string</span>
+            <br>
+            <p class="param-description">Email on the signature.</p>
+          </li>
+          <li class="param-li">
+            <span class="param-name">name</span><span class="param-required">required</span>&nbsp;·&nbsp;<span class="param-type">string</span>
+            <br>
+            <p class="param-description">Name on the signature.</p>
+          </li>
+          <li class="param-li">
+            <span class="param-name">timeOptions</span><span class="param-type">SignatureTimeOptions</span>
+            <br>
+            <ul class="param-ul">
+              <li class="param-li">
+                <span class="param-name">offset</span><span class="param-type">number</span>
+                <br>
+                <p class="param-description">Timezone offset, in minutes</p>
+              </li>
+              <li class="param-li">
+                <span class="param-name">timestamp</span><span class="param-required">required</span>&nbsp;·&nbsp;<span class="param-type">number</span>
+                <br>
+                <p class="param-description">Time in seconds, from epoch</p>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li class="param-li">
+        <span class="param-name">committer</span><span class="param-type">SignaturePayload</span>
+        <br>
+        <p class="param-description">Signature for committer.  If not provided, the default signature of the repository will be used. If there is no default signature set for the repository, an error will occur.</p>
+        <ul class="param-ul">
+          <li class="param-li">
+            <span class="param-name">email</span><span class="param-required">required</span>&nbsp;·&nbsp;<span class="param-type">string</span>
+            <br>
+            <p class="param-description">Email on the signature.</p>
+          </li>
+          <li class="param-li">
+            <span class="param-name">name</span><span class="param-required">required</span>&nbsp;·&nbsp;<span class="param-type">string</span>
+            <br>
+            <p class="param-description">Name on the signature.</p>
+          </li>
+          <li class="param-li">
+            <span class="param-name">timeOptions</span><span class="param-type">SignatureTimeOptions</span>
+            <br>
+            <ul class="param-ul">
+              <li class="param-li">
+                <span class="param-name">offset</span><span class="param-type">number</span>
+                <br>
+                <p class="param-description">Timezone offset, in minutes</p>
+              </li>
+              <li class="param-li">
+                <span class="param-name">timestamp</span><span class="param-required">required</span>&nbsp;·&nbsp;<span class="param-type">number</span>
+                <br>
+                <p class="param-description">Time in seconds, from epoch</p>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li class="param-li">
+        <span class="param-name">parents</span><span class="param-type">string[]</span>
+        <br>
+        <p class="param-description">Parent commit IDs in their intended order.</p>
+      </li>
+    </ul>
+  </li>
+</ul>
+
+### Returns
+
+<ul class="param-ul">
+  <li class="param-li param-li-root">
+    <span class="param-type">string</span>
+    <br>
+    <p class="param-description">Commit content to sign externally.</p>
+  </li>
+</ul>
+
+### Errors
+
+<ul class="param-ul">
+  <li class="param-li param-li-root">
+    <span class="param-type">Error</span>
+    <br>
+    <p class="param-description">If a signature cannot be resolved or a parent commit does not exist.</p>
+  </li>
+</ul>
+
+## Examples
+
+```ts
+const content = repo.commitCreateBuffer(tree, 'signed commit', {
+  parents: [repo.head().target()!],
+});
+const signature = await signingBackend.sign(Buffer.from(content, 'utf8'));
+const oid = repo.commitSigned(content, signature);
+```

--- a/docs/reference/Repository/Methods/commitSigned.md
+++ b/docs/reference/Repository/Methods/commitSigned.md
@@ -1,0 +1,55 @@
+# commitSigned
+
+Create a signed commit from externally signed commit content.
+
+This writes the signed commit to the object database but does not update
+`HEAD` or any other reference. If `signatureField` is omitted, Git's
+default `gpgsig` field is used.
+
+## Signature
+
+```ts
+class Repository {
+  commitSigned(commitContent: string, signature: string, signatureField?: string | null | undefined): string;
+}
+```
+
+### Parameters
+
+<ul class="param-ul">
+  <li class="param-li param-li-root">
+    <span class="param-name">commitContent</span><span class="param-required">required</span>&nbsp;·&nbsp;<span class="param-type">string</span>
+    <br>
+    <p class="param-description">Commit content returned by <code>commitCreateBuffer</code>.</p>
+  </li>
+  <li class="param-li param-li-root">
+    <span class="param-name">signature</span><span class="param-required">required</span>&nbsp;·&nbsp;<span class="param-type">string</span>
+    <br>
+    <p class="param-description">External signature for the commit content.</p>
+  </li>
+  <li class="param-li param-li-root">
+    <span class="param-name">signatureField</span><span class="param-type">string | null</span>
+    <br>
+    <p class="param-description">Signature field name. Defaults to <code>gpgsig</code>.</p>
+  </li>
+</ul>
+
+### Returns
+
+<ul class="param-ul">
+  <li class="param-li param-li-root">
+    <span class="param-type">string</span>
+    <br>
+    <p class="param-description">ID(SHA1) of created commit.</p>
+  </li>
+</ul>
+
+### Errors
+
+<ul class="param-ul">
+  <li class="param-li param-li-root">
+    <span class="param-type">Error</span>
+    <br>
+    <p class="param-description">If the commit content, signature, or signature field is invalid.</p>
+  </li>
+</ul>

--- a/docs/usage/commit.md
+++ b/docs/usage/commit.md
@@ -38,7 +38,9 @@ index.write();
 
 ## Creating Signed Commits
 
-You can create GPG signed commits by providing a signature string:
+External signing is a two-step process. First, create the unsigned commit content and pass its exact UTF-8 bytes to your signing backend. Then, write the signed commit with the returned signature.
+
+Do not normalize whitespace or line endings in the content returned by `commitCreateBuffer()`. `commitSigned()` writes the commit to the object database, but it does not update `HEAD` or another reference.
 
 ```ts
 import { openRepository } from 'es-git';
@@ -49,26 +51,19 @@ const treeOid = index.writeTree();
 const tree = repo.getTree(treeOid);
 
 const signature = { name: 'Seokju Na', email: 'seokju.me@toss.im' };
-
-// Create a signed commit
-const oid = repo.commit(tree, 'signed commit', {
-    updateRef: 'HEAD',
-    author: signature,
-    committer: signature,
-    parents: [repo.head().target()!],
-    signature: '-----BEGIN PGP SIGNATURE-----\\nVersion: GnuPG v1\\n\\niQEcBAABAgAGBQJTest123\\n-----END PGP SIGNATURE-----'
+const commitContent = repo.commitCreateBuffer(tree, 'signed commit', {
+  author: signature,
+  committer: signature,
+  parents: [repo.head().target()!],
 });
 
-// Extract signature from the commit
+// Implement this call with your GPG or other Git-compatible signing backend.
+const externalSignature = await signCommitContent(Buffer.from(commitContent, 'utf8'));
+const oid = repo.commitSigned(commitContent, externalSignature);
+
 const signatureInfo = repo.extractSignature(oid);
-console.log(signatureInfo.signature);
-// {
-//  signature: '-----BEGIN PGP SIGNATURE-----\\nVersion: GnuPG v1\\n\\niQEcBAABAgAGBQJTest123\\n-----END PGP SIGNATURE-----',
-//  signedData: 'tree ab9abf28de846b5968a8f12156f1d5ce3f4a198e\n' +
-//  'parent a01e9888e46729ef4aa68953ba19b02a7a64eb82\n' +
-//  'author Seokju Na <seokju.me@toss.im> 1744517729 +0000\n' +
-//  'committer Seokju Na <seokju.me@toss.im> 1744517729 +0000\n' +
-//  '\n' +
-//  'signed commit'
-// }
+console.log(signatureInfo?.signature === externalSignature); // true
+console.log(signatureInfo?.signedData === commitContent); // true
 ```
+
+If you already have a signature for the exact commit content that `commit()` will create, you can continue to pass it through `CommitOptions.signature`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -3182,6 +3182,66 @@ export declare class Repository {
    */
   getCommit(oid: string): Commit
   /**
+   * Create commit content for external signing.
+   *
+   * This creates the unsigned commit object content without writing it to the
+   * object database. Sign the exact UTF-8 content returned by this method,
+   * then pass both values to `commitSigned`. Changing whitespace or line
+   * endings after signing invalidates the signature.
+   *
+   * @category Repository/Methods
+   *
+   * @signature
+   * ```ts
+   * class Repository {
+   *   commitCreateBuffer(
+   *     tree: Tree,
+   *     message: string,
+   *     options?: CommitCreateBufferOptions | null | undefined,
+   *   ): string;
+   * }
+   * ```
+   *
+   * @param {Tree} tree - Tree object to create commit content from.
+   * @param {string} message - Commit message.
+   * @param {CommitCreateBufferOptions} [options] - Options for creating commit content.
+   * @returns Commit content to sign externally.
+   * @throws If a signature cannot be resolved or a parent commit does not exist.
+   *
+   * @example
+   * ```ts
+   * const content = repo.commitCreateBuffer(tree, 'signed commit', {
+   *   parents: [repo.head().target()!],
+   * });
+   * const signature = await signingBackend.sign(Buffer.from(content, 'utf8'));
+   * const oid = repo.commitSigned(content, signature);
+   * ```
+   */
+  commitCreateBuffer(tree: Tree, message: string, options?: CommitCreateBufferOptions | undefined | null): string
+  /**
+   * Create a signed commit from externally signed commit content.
+   *
+   * This writes the signed commit to the object database but does not update
+   * `HEAD` or any other reference. If `signatureField` is omitted, Git's
+   * default `gpgsig` field is used.
+   *
+   * @category Repository/Methods
+   *
+   * @signature
+   * ```ts
+   * class Repository {
+   *   commitSigned(commitContent: string, signature: string, signatureField?: string | null | undefined): string;
+   * }
+   * ```
+   *
+   * @param {string} commitContent - Commit content returned by `commitCreateBuffer`.
+   * @param {string} signature - External signature for the commit content.
+   * @param {string} [signatureField] - Signature field name. Defaults to `gpgsig`.
+   * @returns ID(SHA1) of created commit.
+   * @throws If the commit content, signature, or signature field is invalid.
+   */
+  commitSigned(commitContent: string, signature: string, signatureField?: string | undefined | null): string
+  /**
    * Create new commit in the repository.
    *
    * If the `updateRef` is not `null`, name of the reference that will be
@@ -7018,6 +7078,25 @@ export interface CherrypickOptions {
  * ```
  */
 export declare function cloneRepository(url: string, path: string, options?: RepositoryCloneOptions | undefined | null, signal?: AbortSignal | undefined | null): Promise<Repository>
+
+export interface CommitCreateBufferOptions {
+  /**
+   * Signature for author.
+   *
+   * If not provided, the default signature of the repository will be used.
+   * If there is no default signature set for the repository, an error will occur.
+   */
+  author?: SignaturePayload
+  /**
+   * Signature for committer.
+   *
+   * If not provided, the default signature of the repository will be used.
+   * If there is no default signature set for the repository, an error will occur.
+   */
+  committer?: SignaturePayload
+  /** Parent commit IDs in their intended order. */
+  parents?: Array<string>
+}
 
 export interface CommitOptions {
   updateRef?: string

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -32,6 +32,22 @@ pub struct CommitOptions {
 }
 
 #[napi(object)]
+pub struct CommitCreateBufferOptions {
+  /// Signature for author.
+  ///
+  /// If not provided, the default signature of the repository will be used.
+  /// If there is no default signature set for the repository, an error will occur.
+  pub author: Option<SignaturePayload>,
+  /// Signature for committer.
+  ///
+  /// If not provided, the default signature of the repository will be used.
+  /// If there is no default signature set for the repository, an error will occur.
+  pub committer: Option<SignaturePayload>,
+  /// Parent commit IDs in their intended order.
+  pub parents: Option<Vec<String>>,
+}
+
+#[napi(object)]
 #[derive(Default)]
 pub struct AmendOptions {
   /// If not NULL, name of the reference that will be updated to point to this commit.
@@ -380,6 +396,116 @@ impl Repository {
     Ok(Commit {
       inner: CommitInner::Repo(commit),
     })
+  }
+
+  #[napi]
+  /// Create commit content for external signing.
+  ///
+  /// This creates the unsigned commit object content without writing it to the
+  /// object database. Sign the exact UTF-8 content returned by this method,
+  /// then pass both values to `commitSigned`. Changing whitespace or line
+  /// endings after signing invalidates the signature.
+  ///
+  /// @category Repository/Methods
+  ///
+  /// @signature
+  /// ```ts
+  /// class Repository {
+  ///   commitCreateBuffer(
+  ///     tree: Tree,
+  ///     message: string,
+  ///     options?: CommitCreateBufferOptions | null | undefined,
+  ///   ): string;
+  /// }
+  /// ```
+  ///
+  /// @param {Tree} tree - Tree object to create commit content from.
+  /// @param {string} message - Commit message.
+  /// @param {CommitCreateBufferOptions} [options] - Options for creating commit content.
+  /// @returns Commit content to sign externally.
+  /// @throws If a signature cannot be resolved or a parent commit does not exist.
+  ///
+  /// @example
+  /// ```ts
+  /// const content = repo.commitCreateBuffer(tree, 'signed commit', {
+  ///   parents: [repo.head().target()!],
+  /// });
+  /// const signature = await signingBackend.sign(Buffer.from(content, 'utf8'));
+  /// const oid = repo.commitSigned(content, signature);
+  /// ```
+  pub fn commit_create_buffer(
+    &self,
+    tree: &Tree,
+    message: String,
+    options: Option<CommitCreateBufferOptions>,
+  ) -> crate::Result<String> {
+    let (author, committer, parents) = match options {
+      Some(opts) => {
+        let parents = match opts.parents {
+          Some(parents) => {
+            let commits: crate::Result<Vec<git2::Commit>> = parents
+              .iter()
+              .map(|x| self.inner.find_commit_by_prefix(x).map_err(crate::Error::from))
+              .collect();
+            Some(commits?)
+          }
+          None => None,
+        };
+        (opts.author, opts.committer, parents)
+      }
+      None => (None, None, None),
+    };
+    let author = match author {
+      Some(author) => git2::Signature::try_from(Signature::try_from(author)?)?,
+      None => self.inner.signature().map_err(|_| crate::Error::SignatureNotFound)?,
+    };
+    let committer = match committer {
+      Some(committer) => git2::Signature::try_from(Signature::try_from(committer)?)?,
+      None => self.inner.signature().map_err(|_| crate::Error::SignatureNotFound)?,
+    };
+
+    let commit_content = self.inner.commit_create_buffer(
+      &author,
+      &committer,
+      &message,
+      &tree.inner,
+      &parents.unwrap_or_default().iter().collect::<Vec<_>>(),
+    )?;
+
+    Ok(std::str::from_utf8(&commit_content)?.to_string())
+  }
+
+  #[napi]
+  /// Create a signed commit from externally signed commit content.
+  ///
+  /// This writes the signed commit to the object database but does not update
+  /// `HEAD` or any other reference. If `signatureField` is omitted, Git's
+  /// default `gpgsig` field is used.
+  ///
+  /// @category Repository/Methods
+  ///
+  /// @signature
+  /// ```ts
+  /// class Repository {
+  ///   commitSigned(commitContent: string, signature: string, signatureField?: string | null | undefined): string;
+  /// }
+  /// ```
+  ///
+  /// @param {string} commitContent - Commit content returned by `commitCreateBuffer`.
+  /// @param {string} signature - External signature for the commit content.
+  /// @param {string} [signatureField] - Signature field name. Defaults to `gpgsig`.
+  /// @returns ID(SHA1) of created commit.
+  /// @throws If the commit content, signature, or signature field is invalid.
+  pub fn commit_signed(
+    &self,
+    commit_content: String,
+    signature: String,
+    signature_field: Option<String>,
+  ) -> crate::Result<String> {
+    let oid = self
+      .inner
+      .commit_signed(&commit_content, &signature, signature_field.as_deref())?;
+    Ok(oid.to_string())
   }
 
   #[napi]

--- a/tests/commit.spec.ts
+++ b/tests/commit.spec.ts
@@ -1,3 +1,4 @@
+import { createHash, generateKeyPairSync, sign, verify } from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -6,6 +7,28 @@ import { useFixture } from './fixtures';
 
 describe('commit', () => {
   const signature = { name: 'Seokju Na', email: 'seokju.me@gmail.com' };
+  const fixedSignature = {
+    ...signature,
+    timeOptions: { timestamp: 1_700_000_000, offset: 0 },
+  };
+  const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+
+  function oidForCommitContent(content: string) {
+    return createHash('sha1')
+      .update(`commit ${Buffer.byteLength(content)}\0${content}`)
+      .digest('hex');
+  }
+
+  function signCommitContent(content: string) {
+    const encoded = sign('sha256', Buffer.from(content, 'utf8'), privateKey).toString('base64');
+    const body = encoded.match(/.{1,64}/g)?.join('\n') ?? encoded;
+    return `-----BEGIN TEST SIGNATURE-----\n${body}\n-----END TEST SIGNATURE-----`;
+  }
+
+  function verifyCommitSignature(content: string, signature: string) {
+    const encoded = signature.split('\n').slice(1, -1).join('');
+    return verify('sha256', Buffer.from(content, 'utf8'), publicKey, Buffer.from(encoded, 'base64'));
+  }
 
   it('get commit', async () => {
     const p = await useFixture('commits');
@@ -72,13 +95,18 @@ describe('commit', () => {
     index.addPath('signed');
     const treeSha = index.writeTree();
     const tree = repo.getTree(treeSha);
+    const parents = [repo.head().target()!];
+    const content = repo.commitCreateBuffer(tree, 'signed commit', {
+      author: fixedSignature,
+      committer: fixedSignature,
+      parents,
+    });
+    const externalSignature = signCommitContent(content);
     const oid = repo.commit(tree, 'signed commit', {
-      updateRef: 'HEAD',
-      author: signature,
-      committer: signature,
-      parents: [repo.head().target()!],
-      signature:
-        '-----BEGIN PGP SIGNATURE-----\\nVersion: GnuPG v1\\n\\niQEcBAABAgAGBQJTest123\\n-----END PGP SIGNATURE-----',
+      author: fixedSignature,
+      committer: fixedSignature,
+      parents,
+      signature: externalSignature,
     });
     expect(isValidOid(oid)).toBe(true);
     const signatureInfo = repo.extractSignature(oid);
@@ -86,15 +114,68 @@ describe('commit', () => {
 
     const { signature: extractedSignature = '', signedData = '' } = signatureInfo || {};
 
-    expect(extractedSignature).toEqual(
-      '-----BEGIN PGP SIGNATURE-----\\nVersion: GnuPG v1\\n\\niQEcBAABAgAGBQJTest123\\n-----END PGP SIGNATURE-----'
-    );
+    expect(extractedSignature).toEqual(externalSignature);
+    expect(signedData).toEqual(content);
+    expect(verifyCommitSignature(signedData, extractedSignature)).toBe(true);
+  });
 
-    expect(signedData).toContain('tree ab9abf28de846b5968a8f12156f1d5ce3f4a198e');
-    expect(signedData).toContain('parent a01e9888e46729ef4aa68953ba19b02a7a64eb82');
-    expect(signedData).toMatch(/author Seokju Na <seokju\.me@gmail\.com> \d+ \+0000/);
-    expect(signedData).toMatch(/committer Seokju Na <seokju\.me@gmail\.com> \d+ \+0000/);
-    expect(signedData).toContain('signed commit');
+  it('creates commit content for external signing without writing an object', async () => {
+    const p = await useFixture('commits');
+    const repo = await openRepository(p);
+    await fs.writeFile(path.join(p, 'buffered'), 'buffered');
+    const index = repo.index();
+    index.addPath('buffered');
+    const tree = repo.getTree(index.writeTree());
+
+    const content = repo.commitCreateBuffer(tree, 'externally signed commit', {
+      author: fixedSignature,
+      committer: fixedSignature,
+      parents: [repo.head().target()!],
+    });
+
+    expect(content).toContain('parent a01e9888e46729ef4aa68953ba19b02a7a64eb82');
+    expect(content).toContain('author Seokju Na <seokju.me@gmail.com> 1700000000 +0000');
+    expect(content).toContain('committer Seokju Na <seokju.me@gmail.com> 1700000000 +0000');
+    expect(content).toContain('externally signed commit');
+    expect(repo.findCommit(oidForCommitContent(content))).toBeNull();
+  });
+
+  it('rejects an invalid explicit signature instead of using the repository default', async () => {
+    const p = await useFixture('commits');
+    const repo = await openRepository(p);
+    const tree = repo.head().peelToTree();
+
+    expect(() =>
+      repo.commitCreateBuffer(tree, 'invalid signature', {
+        author: { name: 'invalid\0name', email: signature.email },
+        committer: fixedSignature,
+      })
+    ).toThrow();
+  });
+
+  it('creates a signed commit from externally signed content', async () => {
+    const p = await useFixture('commits');
+    const repo = await openRepository(p);
+    await fs.writeFile(path.join(p, 'externally-signed'), 'externally-signed');
+    const index = repo.index();
+    index.addPath('externally-signed');
+    const tree = repo.getTree(index.writeTree());
+    const content = repo.commitCreateBuffer(tree, 'externally signed commit', {
+      author: fixedSignature,
+      committer: fixedSignature,
+      parents: [repo.head().target()!],
+    });
+    const externalSignature = signCommitContent(content);
+
+    const oid = repo.commitSigned(content, externalSignature);
+
+    expect(isValidOid(oid)).toBe(true);
+    expect(oid).not.toEqual(oidForCommitContent(content));
+    const signatureInfo = repo.extractSignature(oid);
+    expect(signatureInfo).not.toBeNull();
+    expect(signatureInfo?.signature).toEqual(externalSignature);
+    expect(signatureInfo?.signedData).toEqual(content);
+    expect(verifyCommitSignature(signatureInfo?.signedData ?? '', signatureInfo?.signature ?? '')).toBe(true);
   });
 
   it('extract signature from unsigned commit', async () => {


### PR DESCRIPTION
## Summary

- expose `Repository#commitCreateBuffer` so callers can obtain the exact unsigned commit content without writing an object
- expose `Repository#commitSigned` so an external signature can be attached and written as a commit
- add generated TypeScript declarations plus English and Korean usage/reference documentation
- verify the external-signing flow with cryptographic, multiline-signature, object-write, and invalid-signature tests

## Validation

- `just test`
- `just lint`
- `just typecheck`
- `yarn workspace docs build`

Closes #219